### PR TITLE
added unsummarized trapping router authorization, marked on ROUTES.md

### DIFF
--- a/docs/ROUTES.md
+++ b/docs/ROUTES.md
@@ -113,3 +113,51 @@ Missing values will be ignored.
 ## `DELETE /summarized-rangerdistrict-trapping/:id`
 
 Deletes a row of summarized trapping data by its unique id.
+
+## `GET /unsummarized-trapping/`
+
+Returns all unsummarized trapping data.
+
+## `POST /unsummarized-trapping/`
+
+Creates new entry for unsummarized trapping data. Requires auth.
+
+Expects the following in the body:
+
+- `cleridCount` (type: Number, min: 0)
+- `county` (type: String)
+- `latitude` (type: Number, min: -90, max: 90)
+- `longitude` (type: Number, min: -180, max: 180)
+- `month` (type: Number, min: 1, max: 12)
+- `rangerDistrict` (type: String)
+- `spbCount` (type: Number, min: 0)
+- `state` (type: String)
+- `week` (type: Number, min: 1, max: 52)
+- `year` (type: Number, min: 1900)
+
+## `GET /unsummarized-trapping/:id`
+
+Gets a row of unsummarized trapping data by its unique id.
+
+## `PUT /unsummarized-trapping/:id`
+
+Updates a row of unsummarized trapping data by its unique id. Requires auth.
+
+Expects the following in the body:
+
+- `cleridCount` (type: Number, min: 0)
+- `county` (type: String)
+- `latitude` (type: Number, min: -90, max: 90)
+- `longitude` (type: Number, min: -180, max: 180)
+- `month` (type: Number, min: 1, max: 12)
+- `rangerDistrict` (type: String)
+- `spbCount` (type: Number, min: 0)
+- `state` (type: String)
+- `week` (type: Number, min: 1, max: 52)
+- `year` (type: Number, min: 1900)
+
+Missing values will be ignored.
+
+## `DELETE /unsummarized-trapping/:id`
+
+Deletes a row of unsummarized trapping data by its unique id. Requires auth.

--- a/src/routers/unsummarized-trapping.js
+++ b/src/routers/unsummarized-trapping.js
@@ -7,6 +7,7 @@ import {
 } from '../constants';
 
 import { UnsummarizedTrapping } from '../controllers';
+import { requireAuth } from '../middleware';
 
 const unsummarizedTrappingRouter = Router();
 
@@ -22,7 +23,7 @@ unsummarizedTrappingRouter.route('/')
     }
   })
 
-  .post(async (req, res) => { // add a new document to collection
+  .post(requireAuth, async (req, res) => { // add a new document to collection
     try {
       const documents = await UnsummarizedTrapping.insertOne(req.body);
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, documents));
@@ -44,7 +45,7 @@ unsummarizedTrappingRouter.route('/:id')
     }
   })
 
-  .put(async (req, res) => { // modify a document by its unique id
+  .put(requireAuth, async (req, res) => { // modify a document by its unique id
     try {
       const documents = await UnsummarizedTrapping.updateById(req.params.id, req.body);
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, documents));
@@ -54,7 +55,7 @@ unsummarizedTrappingRouter.route('/:id')
     }
   })
 
-  .delete((async (req, res) => { // delete a document by its unique id
+  .delete(requireAuth, (async (req, res) => { // delete a document by its unique id
     try {
       const documents = await UnsummarizedTrapping.deleteById(req.params.id);
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, documents));


### PR DESCRIPTION
# Description

I added unsummarized trapping router authorization.
I also marked the routes on ROUTES.md. In ROUTES.md, I added some specific requirements to variables required in the body, so that it's easier for people to see what type of data is needed for each variable. 

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Tickets

- closes dali-lab/pine-beetle-frontend#329
