### PR TITLE
Don't install pscl package in R installation

### DIFF
--- a/init.R
+++ b/init.R
@@ -1,1 +1,1 @@
-install.packages("pscl", dependencies = TRUE)
+# install.packages("pscl", dependencies = TRUE)


### PR DESCRIPTION
# Description

- No longer install `pscl` package in build process for R installation

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update