### PR TITLE
Run pipeline after spot and s123 uploads

### DIFF
--- a/src/routers/spot-data-county.js
+++ b/src/routers/spot-data-county.js
@@ -9,7 +9,7 @@ import {
 
 import { RESPONSE_TYPES } from '../constants';
 import { requireAuth } from '../middleware';
-import { SpotDataCounty } from '../controllers';
+import { SpotDataCounty, Pipeline } from '../controllers';
 
 const spotDataCountyRouter = Router();
 
@@ -56,6 +56,7 @@ spotDataCountyRouter.route('/upload')
 
     try {
       await SpotDataCounty.uploadCsv(req.file.path);
+      await Pipeline.runPipelineAll();
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, 'file uploaded successfully'));
     } catch (error) {

--- a/src/routers/spot-data-rangerdistrict.js
+++ b/src/routers/spot-data-rangerdistrict.js
@@ -9,7 +9,7 @@ import {
 
 import { RESPONSE_TYPES } from '../constants';
 import { requireAuth } from '../middleware';
-import { SpotDataRangerDistrict } from '../controllers';
+import { SpotDataRangerDistrict, Pipeline } from '../controllers';
 
 const spotDataRangerDistrictRouter = Router();
 
@@ -56,6 +56,7 @@ spotDataRangerDistrictRouter.route('/upload')
 
     try {
       await SpotDataRangerDistrict.uploadCsv(req.file.path);
+      await Pipeline.runPipelineAll();
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, 'file uploaded successfully'));
     } catch (error) {

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -10,8 +10,8 @@ import {
 import { RESPONSE_TYPES } from '../constants';
 
 import {
-  // UnsummarizedTrapping,
   Survey123,
+  Pipeline,
 } from '../controllers';
 
 const upload = multer({ dest: './uploads' });
@@ -27,6 +27,8 @@ survey123Router.route('/upload')
 
     try {
       await Survey123.uploadCsv(req.file.path);
+      await Pipeline.runPipelineAll();
+
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, 'file uploaded successfully'));
     } catch (error) {
       const errorResponse = generateErrorResponse(error);


### PR DESCRIPTION
# Description

Runs pipeline after spot data csv uploads and survey123-style csv uploads

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Unit/integration tests
- [x] Documentation

## Tickets

- closes #55
