### PR TITLE
2018 summarized upload do not take provided spot data

### DIFF
--- a/src/controllers/summarized-county-trapping.js
+++ b/src/controllers/summarized-county-trapping.js
@@ -31,6 +31,9 @@ const cleanCsv = (row) => ({
   cleridPerDay: row.cleridPerDay ?? {},
   spbCount: row.spbCount ?? null,
   spbPerDay: row.spbPerDay ?? {},
+  spots: null,
+  spotst1: null,
+  spotst2: null,
   totalTrappingDays: row.totalTrappingDays ?? null,
   trapCount: row.trapCount ?? null,
 });

--- a/src/controllers/summarized-rangerdistrict-trapping.js
+++ b/src/controllers/summarized-rangerdistrict-trapping.js
@@ -34,6 +34,9 @@ const cleanCsv = (row) => ({
   cleridPerDay: row.cleridPerDay ?? {},
   spbCount: row.spbCount ?? null,
   spbPerDay: row.spbPerDay ?? {},
+  spots: null,
+  spotst1: null,
+  spotst2: null,
   totalTrappingDays: row.totalTrappingDays ?? null,
   trapCount: row.trapCount ?? null,
 });

--- a/src/routers/summarized-county-trapping.js
+++ b/src/routers/summarized-county-trapping.js
@@ -9,7 +9,7 @@ import {
 
 import { RESPONSE_TYPES } from '../constants';
 import { requireAuth } from '../middleware';
-import { SummarizedCountyTrapping } from '../controllers';
+import { SummarizedCountyTrapping, Pipeline } from '../controllers';
 
 const summarizedCountyTrappingRouter = Router();
 
@@ -100,6 +100,7 @@ summarizedCountyTrappingRouter.route('/upload')
 
     try {
       const uploadResult = await SummarizedCountyTrapping.uploadCsv(req.file.path);
+      Pipeline.runPipelineAll();
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,

--- a/src/routers/summarized-rangerdistrict-trapping.js
+++ b/src/routers/summarized-rangerdistrict-trapping.js
@@ -9,7 +9,7 @@ import {
 
 import { RESPONSE_TYPES } from '../constants';
 import { requireAuth } from '../middleware';
-import { SummarizedRangerDistrictTrapping } from '../controllers';
+import { SummarizedRangerDistrictTrapping, Pipeline } from '../controllers';
 
 const summarizedRangerDistrictTrappingRouter = Router();
 
@@ -100,6 +100,7 @@ summarizedRangerDistrictTrappingRouter.route('/upload')
 
     try {
       const uploadResult = await SummarizedRangerDistrictTrapping.uploadCsv(req.file.path);
+      Pipeline.runPipelineAll();
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,


### PR DESCRIPTION
# Description

Summarized data from 2018 ignores any provided spot data (as that is provided from separate spot data upload which is more accurate). Matt said summarized data from 2018 had estimated spots, not confirmed.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update