### PR TITLE
ParseInt the active days and add cap of 60 active days

### DIFF
--- a/src/constants/csv-to-spots-county.json
+++ b/src/constants/csv-to-spots-county.json
@@ -2,7 +2,6 @@
     "county_parish": "county",
     "fips": "fips",
     "hostAc": "hostAc",
-    "SPB": "spbCount",
     "spots": "spots",
     "state": "state",
     "year": "year"

--- a/src/utils/survey123.js
+++ b/src/utils/survey123.js
@@ -126,15 +126,17 @@ export const deleteInsert = (sixWeeksData) => {
   }
 
   const numDaysActive = sixWeeksData.reduce((acc, curr) => (
-    acc + (curr.daysActive || 0)
+    acc + (parseInt(curr.daysActive, 10) || 0)
   ), 0);
 
-  // only insert if data is valid and at least 12 days total active
-  const insertOps = shouldInsert && numDaysActive >= 12 ? sixWeeksData.map((weekData) => ({
-    insertOne: {
-      document: weekData,
-    },
-  })) : [];
+  // only insert if data is valid and between 12 and 60 days total active
+  const insertOps = shouldInsert && numDaysActive >= 12 && numDaysActive <= 60
+    ? sixWeeksData.map((weekData) => ({
+      insertOne: {
+        document: weekData,
+      },
+    }))
+    : [];
 
   return [
     {


### PR DESCRIPTION
# Description

somehow didn't catch this bug before because the minimum day check somehow worked despite being a string.

added cap of 60 days (not 50 because i think several traps in Texas do 50 ish days, but there are definitely a few mis-entered active days still that we can't do anything about other than enforce it more strictly on survey123)

removed a useless line in json as well

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- closes #105 
