### PR TITLE
fix: explicitly cast empty to null on 2018 summarized uploads

### DIFF
--- a/src/controllers/summarized-county-trapping.js
+++ b/src/controllers/summarized-county-trapping.js
@@ -38,6 +38,12 @@ const cleanCsv = (row) => ({
   trapCount: row.trapCount ?? null,
 });
 
+const nullTransform = (doc) => ({
+  ...doc,
+  cleridPer2Weeks: doc.cleridPer2Weeks !== '' ? doc.cleridPer2Weeks : null,
+  spbPer2Weeks: doc.spbPer2Weeks !== '' ? doc.spbPer2Weeks : null,
+});
+
 /**
  * @description uploads a csv to the summarized county collection
  * @param {String} filename the csv filename on disk
@@ -49,7 +55,7 @@ export const uploadCsv = csvUploadCreator(
   cleanCsv,
   cleanBody,
   undefined,
-  undefined,
+  nullTransform,
   upsertOp,
 );
 

--- a/src/controllers/summarized-rangerdistrict-trapping.js
+++ b/src/controllers/summarized-rangerdistrict-trapping.js
@@ -1,3 +1,5 @@
+import compose from 'compose-function';
+
 import {
   SummarizedRangerDistrictTrappingModel,
   UnsummarizedTrappingModel,
@@ -47,6 +49,14 @@ const rangerDistrictNameTransform = (row) => ({
   rangerDistrict: STATE_RANGER_DISTRICT_NAME_MAPPING[row.state]?.[row.rangerDistrict],
 });
 
+const nullTransform = (doc) => ({
+  ...doc,
+  cleridPer2Weeks: doc.cleridPer2Weeks !== '' ? doc.cleridPer2Weeks : null,
+  spbPer2Weeks: doc.spbPer2Weeks !== '' ? doc.spbPer2Weeks : null,
+});
+
+const rdAndNullTransform = compose(rangerDistrictNameTransform, nullTransform);
+
 /**
  * @description uploads a csv to the summarized ranger district collection
  * @param {String} filename the csv filename on disk
@@ -58,7 +68,7 @@ export const uploadCsv = csvUploadCreator(
   cleanCsv,
   cleanBody,
   undefined,
-  rangerDistrictNameTransform,
+  rdAndNullTransform,
   upsertOp,
 );
 


### PR DESCRIPTION
# Description

2-3 rows on 2018 summarized had null cleridper2weeks but it was incorrectly autocasting to 0; this was overriden

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)
