### PR TITLE
refactor cleanCsv process to make csv-to-spots more idiomatic/meaningful

### DIFF
--- a/src/constants/csv-to-spots-rangerdistrict.json
+++ b/src/constants/csv-to-spots-rangerdistrict.json
@@ -1,5 +1,6 @@
 {
-    "rangerDistrict": "rangerDistrict",
+    "NF": "NF",
+    "NF_RD": "NF_RD",
     "spots": "spots",
     "state": "state",
     "year": "year"

--- a/src/controllers/spot-data-rangerdistrict.js
+++ b/src/controllers/spot-data-rangerdistrict.js
@@ -28,11 +28,14 @@ const modelAttributes = getModelAttributes(SpotDataRangerDistrictModel);
 // this is a function to clean req.body
 const cleanBody = cleanBodyCreator(modelAttributes);
 
-// transforms row of rd spot data to our db format (ranger district name is combo of NF and NF_RD)
-const composedCleanCsv = compose(cleanCsvCreator(CSV_TO_SPOTS_RANGER_DISTRICT), (row) => ({
+// pre-transforms NF/NFRD to RD as final stage of composedCleanCsv below
+const preTransformNFRD = (row) => ({
   ...row,
   rangerDistrict: STATE_NATIONAL_FOREST_RANGER_DISTRICT_NAME_MAPPING[row.state]?.[row.NF]?.[row.NF_RD] ?? null,
-}));
+});
+
+// evaluates right to left: (f o g)(x) = f(g(x))
+const composedCleanCsv = compose(preTransformNFRD, cleanCsvCreator(CSV_TO_SPOTS_RANGER_DISTRICT));
 
 const csvFilterNullRD = ({ rangerDistrict }) => rangerDistrict !== null;
 


### PR DESCRIPTION
# Description

title. This keeps our upload code more consistent (except for survey123 which is going to remain a bit of a mess), and keeps the interface consistent between county and RD spots. In the event that the column names change, refactoring will be easier.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
