### PR TITLE
Omit download fields for summarized and predictions data

### DIFF
--- a/src/controllers/county-prediction.js
+++ b/src/controllers/county-prediction.js
@@ -21,12 +21,18 @@ const modelAttributes = getModelAttributes(CountyPredictionModel);
 // this is a function to clean req.body
 const cleanBody = cleanBodyCreator(modelAttributes);
 
+const downloadFieldsToOmit = ['cleridPerDay', 'spbPerDay', 'prediction'];
+
 /**
  * @description downloads a csv of the entire collection
  * @throws RESPONSE_TYPES.INTERNAL_ERROR for problem parsing CSV
  * @returns {String} path to CSV file
  */
-export const downloadCsv = csvDownloadCreator(CountyPredictionModel, modelAttributes);
+export const downloadCsv = csvDownloadCreator(
+  CountyPredictionModel,
+  modelAttributes.filter((a) => !downloadFieldsToOmit.includes(a)),
+  true,
+);
 
 // upsert transform
 const upsertOp = upsertOpCreator(getIndexes(CountyPredictionModel));

--- a/src/controllers/rd-prediction.js
+++ b/src/controllers/rd-prediction.js
@@ -21,12 +21,18 @@ const modelAttributes = getModelAttributes(RDPredictionModel);
 // this is a function to clean req.body
 const cleanBody = cleanBodyCreator(modelAttributes);
 
+const downloadFieldsToOmit = ['cleridPerDay', 'spbPerDay', 'prediction'];
+
 /**
  * @description downloads a csv of the entire collection
  * @throws RESPONSE_TYPES.INTERNAL_ERROR for problem parsing CSV
  * @returns {String} path to CSV file
  */
-export const downloadCsv = csvDownloadCreator(RDPredictionModel, modelAttributes);
+export const downloadCsv = csvDownloadCreator(
+  RDPredictionModel,
+  modelAttributes.filter((a) => !downloadFieldsToOmit.includes(a)),
+  true,
+);
 
 // upsert transform
 const upsertOp = upsertOpCreator(getIndexes(RDPredictionModel));

--- a/src/controllers/summarized-county-trapping.js
+++ b/src/controllers/summarized-county-trapping.js
@@ -59,12 +59,17 @@ export const uploadCsv = csvUploadCreator(
   upsertOp,
 );
 
+const downloadFieldsToOmit = ['cleridCount', 'cleridPerDay', 'spbCount', 'spbPerDay'];
+
 /**
  * @description downloads a csv of the entire collection
  * @throws RESPONSE_TYPES.INTERNAL_ERROR for problem parsing CSV
  * @returns {String} path to CSV file
  */
-export const downloadCsv = csvDownloadCreator(SummarizedCountyTrappingModel, modelAttributes);
+export const downloadCsv = csvDownloadCreator(
+  SummarizedCountyTrappingModel,
+  modelAttributes.filter((a) => !downloadFieldsToOmit.includes(a)),
+);
 
 /**
  * @description Fetches one year's data from the summarized county collection.

--- a/src/controllers/summarized-rangerdistrict-trapping.js
+++ b/src/controllers/summarized-rangerdistrict-trapping.js
@@ -72,12 +72,17 @@ export const uploadCsv = csvUploadCreator(
   upsertOp,
 );
 
+const downloadFieldsToOmit = ['cleridCount', 'cleridPerDay', 'spbCount', 'spbPerDay'];
+
 /**
  * @description downloads a csv of the entire collection
  * @throws RESPONSE_TYPES.INTERNAL_ERROR for problem parsing CSV
  * @returns {String} path to CSV file
  */
-export const downloadCsv = csvDownloadCreator(SummarizedRangerDistrictTrappingModel, modelAttributes);
+export const downloadCsv = csvDownloadCreator(
+  SummarizedRangerDistrictTrappingModel,
+  modelAttributes.filter((a) => !downloadFieldsToOmit.includes(a)),
+);
 
 /**
  * @description Fetches one year's data from the summarized ranger district collection.

--- a/src/utils/csv-upload.js
+++ b/src/utils/csv-upload.js
@@ -118,10 +118,11 @@ export const csvUploadCreator = (ModelName, cleanCsv, cleanBody, filter, transfo
  * @description higher-order function that creates a csv downloader function
  * @param {mongoose.Model} ModelName destination Model of download
  * @param {Array<String>} fields model attributes in array (used for fields of the csv file)
+ * @param {Boolean} containsPredictionData flag for if prediction field should be spread to columns
  * @returns {(filters: Object) => Promise<String>} which when invoked, returns a filepath to a CSV of the collection contents
  * @throws RESPONSE_TYPES.INTERNAL_ERROR for trouble parsing
  */
-export const csvDownloadCreator = (ModelName, fields) => async (filters) => {
+export const csvDownloadCreator = (ModelName, fields, containsPredictionData = false) => async (filters) => {
   const {
     county,
     endYear,
@@ -141,11 +142,24 @@ export const csvDownloadCreator = (ModelName, fields) => async (filters) => {
     if (rangerDistrict) query.find({ rangerDistrict });
 
     // use compound key to sort before sending the file
-    const data = await query
+    let data = await query
       .sort(ModelName.schema.indexes()[0][0])
       .exec();
 
-    const csv = parse(data, { fields });
+    // spread the predictions object to individual columns
+    if (containsPredictionData) {
+      data = data.map((obj) => ({
+        ...obj._doc,
+        ...obj.prediction,
+      }));
+    }
+
+    const csv = parse(data, {
+      fields: containsPredictionData
+        ? [...fields, ...Object.keys(data[0]?.prediction || {})]
+        : fields,
+    });
+
     const filepath = path.resolve(__dirname, `../../uploads/${Math.random().toString(36).substring(7)}.csv`);
 
     fs.writeFileSync(filepath, csv);


### PR DESCRIPTION
# Description

- Got rid of `spbCount`, `spbPerDay`, `cleridCount`, and `cleridPerDay` fields in all summarized and predictions models
- Also spread predictions objects to individual rows in downloaded CSV

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update