### PR TITLE
edit json files to map rd names better

### DIFF
--- a/src/constants/s123-rd-name-mapping.json
+++ b/src/constants/s123-rd-name-mapping.json
@@ -24,6 +24,7 @@
     "DeSotoNationalForest_DeSotoRD": "DeSoto National Forest (De Soto RD)",
     "DeSotoNationalForest_ChickasawhayRD": "DeSoto National Forest (Chickasawhay RD)",
     "HomochittoNationalForest_HollySpringsRD": "Holly Springs National Forest  (Holly Springs RD)",
+    "HollySpringsNationalForest_HollySpringsRD": "Holly Springs National Forest  (Holly Springs RD)",
     "HomochittoNationalForest_HomochittoRD": "Homochitto National Forest (Homochitto RD)",
     "TombigbeeNationalForest_TombigbeeRD": "Tombigbee National Forest (Tombigbee RD)",
     "CroatanNationalForest_CroatanRD": "Croatan National Forest (Croatan RD)",

--- a/src/constants/state-nf-mapping.json
+++ b/src/constants/state-nf-mapping.json
@@ -48,7 +48,8 @@
         "Croatan Ranger District": "Croatan National Forest (Croatan RD)",
         "Cheoah Ranger District": "Nantahala National Forest (Cheoah RD)",
         "Nantahala Ranger District": "Nantahala National Forest (Nantahala RD)",
-        "Tusquittee Ranger District": "Pisgah National Forest (Grandfather RD)",
+        "Tusquittee Ranger District": "Nantahala National Forest (Tusquitee RD)",
+        "Tusquitee Ranger District": "Nantahala National Forest (Tusquitee RD)",
         "Grandfather Ranger District": "Pisgah National Forest (Grandfather RD)",
         "Uwharrie Ranger District": "Uwharrie National Forest (Uwharrie RD)",
         "Pisgah Ranger District": "Pisgah National Forest (Pisgah RD)"
@@ -63,8 +64,7 @@
     "TN": {
         "Ocoee Ranger District": "Cherokee National Forest (Ocoee RD)",
         "Tellico Ranger District": "Cherokee National Forest (Tellico RD)",
-        "Unaka Ranger District": "Cherokee National Forest (Unaka RD)",
-        "Mount Rogers National Recreation Area": "Cherokee National Forest (Watauga RD)"
+        "Unaka Ranger District": "Cherokee National Forest (Unaka RD)"
     },
     "TX": {
         "Angelina Ranger District": "Angelina National Forest (Angelina RD)",

--- a/src/constants/state-nf-rd-mapping.json
+++ b/src/constants/state-nf-rd-mapping.json
@@ -61,7 +61,8 @@
             "Croatan Ranger District": "Croatan National Forest (Croatan RD)",
             "Cheoah Ranger District": "Nantahala National Forest (Cheoah RD)",
             "Nantahala Ranger District": "Nantahala National Forest (Nantahala RD)",
-            "Tusquittee Ranger District": "Pisgah National Forest (Grandfather RD)",
+            "Tusquittee Ranger District": "Nantahala National Forest (Tusquitee RD)",
+            "Tusquitee Ranger District": "Nantahala National Forest (Tusquitee RD)",
             "Grandfather Ranger District": "Pisgah National Forest (Grandfather RD)",
             "Uwharrie Ranger District": "Uwharrie National Forest (Uwharrie RD)",
             "Pisgah Ranger District": "Pisgah National Forest (Pisgah RD)"
@@ -81,9 +82,6 @@
             "Ocoee Ranger District": "Cherokee National Forest (Ocoee RD)",
             "Tellico Ranger District": "Cherokee National Forest (Tellico RD)",
             "Unaka Ranger District": "Cherokee National Forest (Unaka RD)"
-        },
-        "George Washington and Jefferson National Forest": {
-            "Mount Rogers National Recreation Area": "Cherokee National Forest (Watauga RD)"
         }
     },
     "TX": {


### PR DESCRIPTION
# Description

some rd names needed changes.

- George Washington and Jefferson National Forest was removed from TN since that should only be in VA.
- Tusquitee's correct spelling was added (two t's is wrong but used occasionally so it's kept), and it's mapped rd was changed to be correct.
- one of the holly springs rd mappings was missing, so I added it to fix several predictions.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

