### PR TITLE
Jl/fix rmodel

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "mongoose": "^6.4.6",
     "morgan": "^1.9.0",
     "multer": "^1.4.2",
-    "numeral": "^2.0.6",
-    "r-script": "^0.0.4"
+    "numeral": "^2.0.6"
   },
   "devDependencies": {
     "eslint": "^8.38.0",

--- a/src/controllers/pipeline.js
+++ b/src/controllers/pipeline.js
@@ -104,8 +104,7 @@ export const runPipelineAll = async () => {
     };
   } catch (error) {
     console.log('ERROR RUNNING PIPELINE');
-    console.log(error);
-    return error;
+    throw error;
   }
 };
 

--- a/src/controllers/r-model.js
+++ b/src/controllers/r-model.js
@@ -1,33 +1,12 @@
-/* eslint-disable new-cap */
 import path from 'path';
-import R from 'r-script';
 import {
-  // R,
+  callRScript,
   newError,
 } from '../utils';
 import { RESPONSE_TYPES } from '../constants';
 
 const rPredictionPath = path.resolve(__dirname, '../r-scripts/SPB-Predictions.v02-DALI.R');
 const rCalculatedFieldsPath = path.resolve(__dirname, '../r-scripts/Calculated-Outcome-Fields.R');
-
-/**
- * promise wrapper around r-script npm package
- * @param {string} rPath path to r script
- * @param {array} data the input to r script
- */
-const rPromiseWrapper = async (rPath, ...args) => {
-  return new Promise((resolve, reject) => {
-    R(rPath)
-      .data(...args)
-      .call((error, d) => {
-        if (error) {
-          reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
-        } else {
-          resolve(d);
-        }
-      });
-  });
-};
 
 /**
  * runs the r model by feeding it an array of entries
@@ -74,7 +53,7 @@ export const runModel = (array) => {
 
   if (!data.length) return data;
 
-  return rPromiseWrapper(rPredictionPath, { data });
+  return callRScript(rPredictionPath, { data });
 };
 
 /**
@@ -101,5 +80,5 @@ export const generateCalculatedFields = (array) => {
 
   if (!data.length) return data;
 
-  return rPromiseWrapper(rCalculatedFieldsPath, { data });
+  return callRScript(rCalculatedFieldsPath, { data });
 };

--- a/src/controllers/r-model.js
+++ b/src/controllers/r-model.js
@@ -58,7 +58,7 @@ export const runModel = (array) => {
         .data({ data })
         .call((error, d) => {
           if (error) {
-            reject(error);
+            reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
           } else {
             resolve(d);
           }
@@ -97,7 +97,7 @@ export const generateCalculatedFields = (array) => {
         .data({ data })
         .call((error, d) => {
           if (error) {
-            reject(error);
+            reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
           } else {
             resolve(d);
           }

--- a/src/controllers/r-model.js
+++ b/src/controllers/r-model.js
@@ -15,21 +15,17 @@ const rCalculatedFieldsPath = path.resolve(__dirname, '../r-scripts/Calculated-O
  * @param {string} rPath path to r script
  * @param {array} data the input to r script
  */
-const rPromiseWrapper = async (rPath, data) => {
+const rPromiseWrapper = async (rPath, ...args) => {
   return new Promise((resolve, reject) => {
-    if (!data.length) {
-      resolve(data);
-    } else {
-      R(rPath)
-        .data({ data })
-        .call((error, d) => {
-          if (error) {
-            reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
-          } else {
-            resolve(d);
-          }
-        });
-    }
+    R(rPath)
+      .data(...args)
+      .call((error, d) => {
+        if (error) {
+          reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
+        } else {
+          resolve(d);
+        }
+      });
   });
 };
 
@@ -76,7 +72,9 @@ export const runModel = (array) => {
     };
   });
 
-  return rPromiseWrapper(rPredictionPath, data);
+  if (!data.length) return data;
+
+  return rPromiseWrapper(rPredictionPath, { data });
 };
 
 /**
@@ -101,5 +99,7 @@ export const generateCalculatedFields = (array) => {
     };
   });
 
-  return rPromiseWrapper(rCalculatedFieldsPath, data);
+  if (!data.length) return data;
+
+  return rPromiseWrapper(rCalculatedFieldsPath, { data });
 };

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -164,7 +164,9 @@ export const uploadSurvey123FromWebhook = async (rawData) => {
   const deleteInsertRes = await UnsummarizedTrappingModel.bulkWrite(deleteInsertOp, { ordered: true });
 
   // run entire pipeline
-  runPipelineAll();
+  // don't throw the error here since we want the webhook to return 200 immediately
+  // also don't await it for the same purpose; run pipeline in background
+  runPipelineAll().catch(console.log);
 
   return deleteInsertRes;
 };

--- a/src/r-scripts/launch.R
+++ b/src/r-scripts/launch.R
@@ -1,0 +1,43 @@
+# slightly modified version of https://github.com/joshkatz/r-script/blob/master/R/launch.R
+# does not use needs.R now; it directly imports jsonlite
+# also reads from stdin instead of from env
+
+library(jsonlite)
+
+run <- function(dataIn) {
+
+  # set up environment
+  input <- unname(dataIn[[1]])
+  .e <- as.environment(list(
+    path = dataIn[[2]],
+    out = modifyList(list(x = NULL, auto_unbox = T),
+      dataIn[[3]], keep.null = T)
+  ))
+  lockBinding(".e", environment())
+
+  # run source, capture output
+  captured <- tryCatch(capture.output({
+    temp <- source(.e$path, local = T)$value
+  }), error = function(err) err)
+  unlockBinding(".e", environment())
+
+  # process and return
+  if (inherits(captured, "error")) {
+    msg <- conditionMessage(captured)
+    cat("Error in R script", .e$path, "\n", sQuote(msg), file = stderr())
+    return(invisible(F))
+  }
+  .e$out$x <- if (is.null(temp)) {
+     ""
+  } else {
+    temp
+  }
+  do.call(toJSON, .e$out)
+}
+
+f <- file("stdin", "r")
+lines <- readLines(con = f, n=1)
+suppressWarnings(
+  run(fromJSON(lines))
+)
+close(f)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -36,6 +36,8 @@ import {
   transformSurvey123GlobalID,
 } from './survey123';
 
+import { callRScript } from './r-launcher';
+
 export {
   calculatedFieldsGeneratorCreator,
   csvDownloadCreator,
@@ -53,6 +55,7 @@ export {
   predictionGeneratorCreator,
   processCSV,
   processCSVAsync,
+  callRScript,
   transformSurvey123GlobalID,
   trappingAggregationPipelineCreator,
   upsertOpCreator,

--- a/src/utils/r-launcher.js
+++ b/src/utils/r-launcher.js
@@ -1,0 +1,66 @@
+/* eslint-disable import/prefer-default-export */
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+import { newError } from './responses';
+import { RESPONSE_TYPES } from '../constants';
+
+/**
+ * rewritten version of r-script npm package to asyncronously call an R script
+ * check https://github.com/joshkatz/r-script/blob/master/index.js for original code
+ *
+ * uses stdin to pipe input into R instead of env variables, since the original
+ * package caused E2BIG with large amounts of input.
+ * this is because there's a kernel-based limit on how many bytes can be in
+ * command line args + env variables, and the original package would use env variables
+ * to send all the data. stdin should be unbounded so this works better.
+ *
+ * @param {string} rPath path to R script to run
+ * @param {...Object} dataArgs data to pass to script
+ * @returns {Promise<Object[]>} output from R
+ */
+export const callRScript = async (rPath, ...dataArgs) => {
+  // these options are passed to jsonlite for toJSON
+  // https://github.com/jeroenooms/jsonlite/blob/master/R/toJSON.R
+  const options = {};
+
+  const args = ['--vanilla', path.resolve(__dirname, '../r-scripts/launch.R')];
+
+  // this is just to stay consistent with npm package r-script
+  const inputData = dataArgs.reduce((acc, arg, i) => ({
+    ...acc,
+    [i + 1]: arg,
+  }), {});
+
+  const child = spawn('Rscript', args);
+
+  // needs newline at the end; or else R complains and throws an error
+  const input = `${JSON.stringify([inputData, rPath, options])}\n`;
+  child.stdin.end(input);
+
+  return new Promise((resolve, reject) => {
+    child.stderr.on('data', (error) => {
+      // error comes in as a buffer, so it needs to become a string
+      return reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
+    });
+
+    let body = '';
+    child.stdout.on('data', (d) => {
+      body += d;
+    });
+
+    child.on('close', (exitCode) => {
+      try {
+        // don't resolve if a non-zero error code happened bc we should have rejected already
+        if (exitCode === 0) {
+          resolve(JSON.parse(body));
+        }
+        if (exitCode !== 0) {
+          reject();
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+};

--- a/src/utils/r-launcher.js
+++ b/src/utils/r-launcher.js
@@ -15,6 +15,9 @@ import { RESPONSE_TYPES } from '../constants';
  * command line args + env variables, and the original package would use env variables
  * to send all the data. stdin should be unbounded so this works better.
  *
+ * see https://www.in-ulm.de/~mascheck/various/argmax/ for kernel details on this
+ * https://code.whatever.social/questions/46897008/why-am-i-getting-e2big-from-exec-when-im-accounting-for-the-arguments-and-the
+ *
  * @param {string} rPath path to R script to run
  * @param {...Object} dataArgs data to pass to script
  * @returns {Promise<Object[]>} output from R

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,13 +3839,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-r-script@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/r-script/-/r-script-0.0.4.tgz#b7337d0a36b27691cba0cf1f60a912bbd646abe1"
-  integrity sha512-PNUS0iQGHLSzKCaTI8HZs5pw20GSJVaIhuBEPY3QYoUmf1RXUAnTcof0G6uMp8jGr9Ke2n/rhXVC6B1m/iiWCA==
-  dependencies:
-    underscore "^1.8.3"
-
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -4328,11 +4321,6 @@ undefsafe@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
-
-underscore@^1.8.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.3.tgz#54bc95f7648c5557897e5e968d0f76bc062c34ee"
-  integrity sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Description

rewrites the npm r-model package to properly use stdin instead of env to pass data, as well as better error handling.

closes #169 

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)
