### PR TITLE
Fix CSV upload field names, globalID normalization, and error handling

### DIFF
--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -60,7 +60,7 @@ export const uploadCsv = async (filename) => {
         daysActive: sixWeekData[`TrappingInterval${weekNum}`],
         endobrev: 1,
         FIPS: null,
-        globalID: sixWeekData.globalid || sixWeekData.GlobalID,
+        globalID: transformSurvey123GlobalID(sixWeekData.globalid || sixWeekData.GlobalID),
         latitude: sixWeekData.Latitude,
         longitude: sixWeekData.Longitude,
         lure: sixWeekData.Trap_Lure,

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -46,12 +46,13 @@ const ordinalStrings = Object.entries({
  */
 export const uploadCsv = async (filename) => {
   const unpacker = (sixWeekData) => {
-    return ordinalStrings.map(([weekNum]) => {
+    // detect CSV format: new field names use underscores, old ones use spaces/special chars
+    const isNewFormat = sixWeekData.USA_State !== undefined;
+
+    return ordinalStrings.map(([weekNum, weekOrdinal]) => {
       // convert fields to unsummarized schema
-      // this tracks the csv export format from survey123.arcgis.com per the data upload guide.
-      // this may change over time if spelling changes etc, so retry the download and read the
-      // csv columns if needed.
-      const convertedRawData = {
+      // supports both old and new Survey123 CSV export formats
+      const convertedRawData = isNewFormat ? {
         bloom: sixWeekData.Species_Bloom,
         bloomDate: sixWeekData.Initial_Bloom,
         cleridCount: sixWeekData[`Number_Clerids${weekNum}`],
@@ -72,20 +73,41 @@ export const uploadCsv = async (filename) => {
         state: sixWeekData.USA_State,
         trap: sixWeekData.Trap_name,
         year: sixWeekData.Year,
+      } : {
+        bloom: sixWeekData['What bloomed?'],
+        bloomDate: sixWeekData['Date of Inital bloom'],
+        cleridCount: sixWeekData[`Number Clerids (${weekOrdinal} Collection)`],
+        collectionDate: sixWeekData[`Date of Collection ${weekNum}`],
+        county: sixWeekData['County/Parish'],
+        daysActive: sixWeekData[`Active Trapping Days (${weekOrdinal} Collection)`],
+        endobrev: 1,
+        FIPS: null,
+        globalID: sixWeekData.GlobalID,
+        latitude: sixWeekData.Latitude,
+        longitude: sixWeekData.Longitude,
+        lure: sixWeekData['Trap Lure'],
+        rangerDistrict: sixWeekData['National Forest (Ranger District)'],
+        season: sixWeekData.Season,
+        sirexLure: 'Y',
+        spbCount: sixWeekData[`Number SPB (${weekOrdinal} Collection)`],
+        startDate: sixWeekData['Traps set out on:'],
+        state: sixWeekData.State,
+        trap: sixWeekData['Trap name'],
+        year: sixWeekData.Year,
       };
 
       // will throw error if missing fields
       const cleanedData = extractModelAttributes(convertedRawData);
 
-      // copied from utils/extractObjectFieldsCreator
-      const missingFields = ['DeleteSurvey', 'Is_Final_Collection'].filter((field) => sixWeekData[field] === undefined);
+      const deleteField = isNewFormat ? 'DeleteSurvey' : 'Delete this survey?';
+      const missingFields = [deleteField, 'Is_Final_Collection'].filter((field) => sixWeekData[field] === undefined);
       if (missingFields.length > 0) {
         throw newError(RESPONSE_TYPES.BAD_REQUEST, `missing fields: ${missingFields}`);
       }
 
       if (!cleanedData.collectionDate || !cleanedData.daysActive || cleanedData.daysActive === '0') return undefined; // no data for this week
 
-      const shouldDeleteSurvey = sixWeekData.DeleteSurvey === 'yes';
+      const shouldDeleteSurvey = sixWeekData[deleteField] === 'yes';
       const isFinalCollection = sixWeekData.Is_Final_Collection === 'yes';
 
       return {

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -46,31 +46,31 @@ const ordinalStrings = Object.entries({
  */
 export const uploadCsv = async (filename) => {
   const unpacker = (sixWeekData) => {
-    return ordinalStrings.map(([weekNum, weekOrdinal]) => {
+    return ordinalStrings.map(([weekNum]) => {
       // convert fields to unsummarized schema
       // this tracks the csv export format from survey123.arcgis.com per the data upload guide.
       // this may change over time if spelling changes etc, so retry the download and read the
       // csv columns if needed.
       const convertedRawData = {
-        bloom: sixWeekData['What bloomed?'],
-        bloomDate: sixWeekData['Date of Inital bloom'], // fix spelling
-        cleridCount: sixWeekData[`Number Clerids (${weekOrdinal} Collection)`],
-        collectionDate: sixWeekData[`Date of Collection ${weekNum}`],
-        county: sixWeekData['County/Parish'],
-        daysActive: sixWeekData[`Active Trapping Days (${weekOrdinal} Collection)`],
+        bloom: sixWeekData.Species_Bloom,
+        bloomDate: sixWeekData.Initial_Bloom,
+        cleridCount: sixWeekData[`Number_Clerids${weekNum}`],
+        collectionDate: sixWeekData[`CollectionDate${weekNum}`],
+        county: sixWeekData.County,
+        daysActive: sixWeekData[`TrappingInterval${weekNum}`],
         endobrev: 1,
         FIPS: null,
         globalID: sixWeekData.GlobalID,
         latitude: sixWeekData.Latitude,
         longitude: sixWeekData.Longitude,
-        lure: sixWeekData['Trap Lure'],
-        rangerDistrict: sixWeekData['National Forest (Ranger District)'],
+        lure: sixWeekData.Trap_Lure,
+        rangerDistrict: sixWeekData.Nat_Forest_Ranger_Dist,
         season: sixWeekData.Season,
         sirexLure: 'Y',
-        spbCount: sixWeekData[`Number SPB (${weekOrdinal} Collection)`],
-        startDate: sixWeekData['Traps set out on:'],
-        state: sixWeekData.State,
-        trap: sixWeekData['Trap name'],
+        spbCount: sixWeekData[`Number_SPB${weekNum}`],
+        startDate: sixWeekData.TrapSetDate,
+        state: sixWeekData.USA_State,
+        trap: sixWeekData.Trap_name,
         year: sixWeekData.Year,
       };
 
@@ -78,14 +78,14 @@ export const uploadCsv = async (filename) => {
       const cleanedData = extractModelAttributes(convertedRawData);
 
       // copied from utils/extractObjectFieldsCreator
-      const missingFields = ['Delete this survey?', 'Is_Final_Collection'].filter((field) => sixWeekData[field] === undefined);
+      const missingFields = ['DeleteSurvey', 'Is_Final_Collection'].filter((field) => sixWeekData[field] === undefined);
       if (missingFields.length > 0) {
         throw newError(RESPONSE_TYPES.BAD_REQUEST, `missing fields: ${missingFields}`);
       }
 
       if (!cleanedData.collectionDate || !cleanedData.daysActive || cleanedData.daysActive === '0') return undefined; // no data for this week
 
-      const shouldDeleteSurvey = sixWeekData['Delete this survey?'] === 'yes';
+      const shouldDeleteSurvey = sixWeekData.DeleteSurvey === 'yes';
       const isFinalCollection = sixWeekData.Is_Final_Collection === 'yes';
 
       return {

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -60,7 +60,7 @@ export const uploadCsv = async (filename) => {
         daysActive: sixWeekData[`TrappingInterval${weekNum}`],
         endobrev: 1,
         FIPS: null,
-        globalID: sixWeekData.GlobalID,
+        globalID: sixWeekData.globalid || sixWeekData.GlobalID,
         latitude: sixWeekData.Latitude,
         longitude: sixWeekData.Longitude,
         lure: sixWeekData.Trap_Lure,

--- a/src/routers/summarized-county.js
+++ b/src/routers/summarized-county.js
@@ -90,7 +90,7 @@ summarizedCountyRouter.route('/spots/upload')
 
     try {
       const uploadResult = await SummarizedCounty.uploadSpotsCsv(req.file.path);
-      Pipeline.runPipelineAll();
+      Pipeline.runPipelineAll().catch(console.error);
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
@@ -118,7 +118,7 @@ summarizedCountyRouter.route('/upload')
 
     try {
       const uploadResult = await SummarizedCounty.uploadCsv(req.file.path);
-      Pipeline.runPipelineAll();
+      Pipeline.runPipelineAll().catch(console.error);
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,

--- a/src/routers/summarized-county.js
+++ b/src/routers/summarized-county.js
@@ -90,7 +90,7 @@ summarizedCountyRouter.route('/spots/upload')
 
     try {
       const uploadResult = await SummarizedCounty.uploadSpotsCsv(req.file.path);
-      Pipeline.runPipelineAll().catch(console.error);
+      Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
@@ -118,7 +118,7 @@ summarizedCountyRouter.route('/upload')
 
     try {
       const uploadResult = await SummarizedCounty.uploadCsv(req.file.path);
-      Pipeline.runPipelineAll().catch(console.error);
+      Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,

--- a/src/routers/summarized-rangerdistrict.js
+++ b/src/routers/summarized-rangerdistrict.js
@@ -90,7 +90,7 @@ summarizedRangerDistrictRouter.route('/spots/upload')
 
     try {
       const uploadResult = await SummarizedRangerDistrict.uploadSpotsCsv(req.file.path);
-      Pipeline.runPipelineAll();
+      Pipeline.runPipelineAll().catch(console.error);
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
@@ -118,7 +118,7 @@ summarizedRangerDistrictRouter.route('/upload')
 
     try {
       const uploadResult = await SummarizedRangerDistrict.uploadCsv(req.file.path);
-      Pipeline.runPipelineAll();
+      Pipeline.runPipelineAll().catch(console.error);
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,

--- a/src/routers/summarized-rangerdistrict.js
+++ b/src/routers/summarized-rangerdistrict.js
@@ -90,7 +90,7 @@ summarizedRangerDistrictRouter.route('/spots/upload')
 
     try {
       const uploadResult = await SummarizedRangerDistrict.uploadSpotsCsv(req.file.path);
-      Pipeline.runPipelineAll().catch(console.error);
+      Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
@@ -118,7 +118,7 @@ summarizedRangerDistrictRouter.route('/upload')
 
     try {
       const uploadResult = await SummarizedRangerDistrict.uploadCsv(req.file.path);
-      Pipeline.runPipelineAll().catch(console.error);
+      Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,

--- a/src/utils/r-launcher.js
+++ b/src/utils/r-launcher.js
@@ -42,9 +42,9 @@ export const callRScript = async (rPath, ...dataArgs) => {
   child.stdin.end(input);
 
   return new Promise((resolve, reject) => {
-    child.stderr.on('data', (error) => {
-      // error comes in as a buffer, so it needs to become a string
-      return reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, error.toString()));
+    let stderrOutput = '';
+    child.stderr.on('data', (data) => {
+      stderrOutput += data.toString();
     });
 
     let body = '';
@@ -54,15 +54,16 @@ export const callRScript = async (rPath, ...dataArgs) => {
 
     child.on('close', (exitCode) => {
       try {
-        // don't resolve if a non-zero error code happened bc we should have rejected already
         if (exitCode === 0) {
+          if (stderrOutput) {
+            console.warn(`R script warning: ${stderrOutput}`);
+          }
           resolve(JSON.parse(body));
+        } else {
+          reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, stderrOutput || `R script exited with code ${exitCode}`));
         }
-        if (exitCode !== 0) {
-          reject();
-        }
-      } catch (error) {
-        reject(error);
+      } catch (parseError) {
+        reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, stderrOutput || parseError.message));
       }
     });
   });

--- a/src/utils/r-launcher.js
+++ b/src/utils/r-launcher.js
@@ -63,7 +63,7 @@ export const callRScript = async (rPath, ...dataArgs) => {
           reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, stderrOutput || `R script exited with code ${exitCode}`));
         }
       } catch (parseError) {
-        reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, stderrOutput || parseError.message));
+        reject(newError(RESPONSE_TYPES.INTERNAL_ERROR, `JSON parse failed: ${parseError.message}${stderrOutput ? `\nR stderr: ${stderrOutput}` : ''}`));
       }
     });
   });


### PR DESCRIPTION
# Description

- Update CSV upload field names to match current Survey123 export format
- Normalize globalID in CSV upload path using transformSurvey123GlobalID to ensure consistency with webhook path
- Buffer R stderr output instead of rejecting on first chunk to prevent crashes on R warnings
- Add .catch() to fire-and-forget runPipelineAll() calls to prevent unhandled promise rejections
- Include both parse error and R stderr in error messages for easier debugging

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)
