### PR TITLE
Fix duplicate /v3 prefix in auth middleware URL

### DIFF
--- a/src/middleware/require-auth.js
+++ b/src/middleware/require-auth.js
@@ -25,7 +25,7 @@ const requireAuth = async (req, res, next) => {
 
   try {
     // auth with main backend
-    const response = await axios.get(`${MAIN_BACKEND_ROUTE}/v3/user/auth`, {
+    const response = await axios.get(`${MAIN_BACKEND_ROUTE}/user/auth`, {
       headers: {
         authorization,
       },


### PR DESCRIPTION
# Description

Fix duplicate /v3 prefix in auth middleware URL

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)
