### PR TITLE
Fix: async survey123 upload to avoid Heroku H12 timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ We use higher-order functions with dependency injection for behaviors repeated a
 
 Continuous deployment is setup with Heroku.
 
-Merging a PR to the `dev` branch will trigger a new build in the dev environment. When the build passes, an update will be released at [https://pine-beetle-prediction-dev.herokuapp.com](https://pine-beetle-prediction-dev.herokuapp.com).
+Merging a PR to the `dev` branch will trigger a new build in the dev environment. When the build passes, an update will be released at [https://pine-beetle-automation-dev-7702db82f77e.herokuapp.com](https://pine-beetle-automation-dev-7702db82f77e.herokuapp.com).
 
-Merging a PR to the `release` branch will trigger a new build in the production environment. When the build passes, an update will be released at [https://pine-beetle-prediction.herokuapp.com](https://pine-beetle-prediction.herokuapp.com).
+Merging a PR to the `release` branch will trigger a new build in the production environment. When the build passes, an update will be released at [https://pine-beetle-automation-6ba2941e05d1.herokuapp.com](https://pine-beetle-automation-6ba2941e05d1.herokuapp.com).
 
 Pull requests should always be first merged into the `dev` branch so they are staged in the development environment. After smoke testing the changes in the development environment, developers can then choose to release those changes into production by generating a `DEV TO RELEASE` pull request from the `dev` branch to the `release` branch. One this single PR is merged into `release`, the changes will be built into the production environment and will be accessible at the release API.
 

--- a/docs/survey123.md
+++ b/docs/survey123.md
@@ -1,8 +1,12 @@
 # `/survey123` routes
 
-## `GET /upload`
+## `POST /upload`
 
-Uploads a CSV of survey-123 style unsummarized data. This file can be directly downloaded from the Survey123 interface. Expects a `csv` file field in the body. Requires auth. Expects the following column names in the csv file (this might become outdated over time):
+Uploads a CSV of survey-123 style unsummarized data. The server responds immediately with **202 Accepted** and processes the file in the background (avoids Heroku’s 30s request timeout). Expects a `csv` file field in the body. Requires auth.
+
+The CSV file can be downloaded directly from the [Survey123](https://survey123.arcgis.com/) interface and then uploaded here. To export unsummarized data as CSV from this API, use `GET /v3/unsummarized-trapping/download` (see [unsummarized-trapping](./unsummarized-trapping.md)).
+
+Expects the following column names in the csv file (this might become outdated over time):
 
 - `ObjectID`
 - `GlobalID`

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,9 @@ dotenv.config({ silent: true });
 // DB Setup
 const mongoURI = process.env.MONGODB_URI || 'mongodb://localhost/pb-dev';
 
+// Prepare for Mongoose 7 (suppresses strictQuery deprecation warning)
+mongoose.set('strictQuery', false);
+
 const mongooseOptions = {
   loggerLevel: 'error',
   useNewUrlParser: true,

--- a/src/middleware/require-auth.js
+++ b/src/middleware/require-auth.js
@@ -14,13 +14,22 @@ import { generateResponse } from '../utils';
  * @param {Function} next function for proceeding with middleware
  */
 const requireAuth = async (req, res, next) => {
-  const { MAIN_BACKEND_ROUTE } = process.env;
+  let { MAIN_BACKEND_ROUTE } = process.env;
+  // ensure base URL without trailing /v3 so we don't get /v3/v3/user/auth
+  if (MAIN_BACKEND_ROUTE) {
+    MAIN_BACKEND_ROUTE = MAIN_BACKEND_ROUTE.replace(/\/v3\/?$/, '');
+  }
   const { authorization } = req.headers;
 
   // send unauthorized if no auth header
   if (!authorization) {
     return res.status(RESPONSE_CODES.UNAUTHORIZED.status)
       .send(generateResponse(RESPONSE_TYPES.UNAUTHORIZED));
+  }
+
+  if (!MAIN_BACKEND_ROUTE) {
+    return res.status(RESPONSE_CODES.INTERNAL_ERROR.status)
+      .send(generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, 'MAIN_BACKEND_ROUTE is not configured'));
   }
 
   try {

--- a/src/middleware/require-auth.js
+++ b/src/middleware/require-auth.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 import {
-    RESPONSE_CODES,
-    RESPONSE_TYPES,
+  RESPONSE_CODES,
+  RESPONSE_TYPES,
 } from '../constants';
 
 import { generateResponse } from '../utils';

--- a/src/middleware/require-auth.js
+++ b/src/middleware/require-auth.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 import {
-  RESPONSE_CODES,
-  RESPONSE_TYPES,
+    RESPONSE_CODES,
+    RESPONSE_TYPES,
 } from '../constants';
 
 import { generateResponse } from '../utils';
@@ -14,22 +14,13 @@ import { generateResponse } from '../utils';
  * @param {Function} next function for proceeding with middleware
  */
 const requireAuth = async (req, res, next) => {
-  let { MAIN_BACKEND_ROUTE } = process.env;
-  // ensure base URL without trailing /v3 so we don't get /v3/v3/user/auth
-  if (MAIN_BACKEND_ROUTE) {
-    MAIN_BACKEND_ROUTE = MAIN_BACKEND_ROUTE.replace(/\/v3\/?$/, '');
-  }
+  const { MAIN_BACKEND_ROUTE } = process.env;
   const { authorization } = req.headers;
 
   // send unauthorized if no auth header
   if (!authorization) {
     return res.status(RESPONSE_CODES.UNAUTHORIZED.status)
       .send(generateResponse(RESPONSE_TYPES.UNAUTHORIZED));
-  }
-
-  if (!MAIN_BACKEND_ROUTE) {
-    return res.status(RESPONSE_CODES.INTERNAL_ERROR.status)
-      .send(generateResponse(RESPONSE_TYPES.INTERNAL_ERROR, 'MAIN_BACKEND_ROUTE is not configured'));
   }
 
   try {

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -24,24 +24,19 @@ survey123Router.route('/upload')
       return;
     }
 
-    try {
-      const uploadResult = await Survey123.uploadCsv(req.file.path);
+    // Always process in background: return 202 immediately to avoid Heroku 30s H12 timeout.
+    // Upload + pipeline can take longer than 30s for larger files.
+    res.status(202).send(generateResponse(RESPONSE_TYPES.SUCCESS, {
+      message: 'Upload accepted, processing in background. Pipeline will run after data is saved.',
+    }));
 
-      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
-        data: uploadResult,
-        message: 'file uploaded successfully',
-      }));
-    } catch (error) {
-      const errorResponse = generateErrorResponse(error);
-      const { error: errorMessage, status } = errorResponse;
-      console.error(errorMessage);
-      res.status(status).send(errorResponse);
-    } finally {
-      // wrapping in a setTimeout to invoke the event loop, so fs knows the file exists
-      setTimeout(() => {
-        deleteFile(req.file.path);
-      }, 1000 * 10);
-    }
+    const filePath = req.file.path;
+    setImmediate(() => {
+      Survey123.uploadCsv(filePath)
+        .then(() => console.log('csv upload completed successfully'))
+        .catch((err) => console.error('csv upload failed:', err))
+        .finally(() => deleteFile(filePath));
+    });
   });
 
 survey123Router.route('/webhook')

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -35,7 +35,10 @@ survey123Router.route('/upload')
       Survey123.uploadCsv(filePath)
         .then(() => console.log('csv upload completed successfully'))
         .catch((err) => console.error('csv upload failed:', err))
-        .finally(() => deleteFile(filePath));
+        .finally(() => {
+          // delay so fs has flushed; then remove temp file
+          setTimeout(() => deleteFile(filePath), 1000 * 10);
+        });
     });
   });
 


### PR DESCRIPTION
# Description

Survey123 upload always returns 202 and processes the CSV in the background so Heroku’s 30s limit no longer causes H12 timeouts. Also adds a Mongoose strictQuery fix to remove the deprecation warning and updates the docs.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)
