### PR TITLE
Fix CSV upload timeout

### DIFF
--- a/src/controllers/summarized-county.js
+++ b/src/controllers/summarized-county.js
@@ -129,7 +129,7 @@ export const getByFilter = async (startYear, endYear, state, county, page, limit
   const parsedLimit = Math.min(5000, Math.max(1, parseInt(limit, 10) || 1000)); // max 5000 per page
 
   const skip = (parsedPage - 1) * parsedLimit;
-  const total = await query.countDocuments();
+  const total = await query.model.countDocuments(query.getFilter());
 
   const data = await query
     .sort({

--- a/src/controllers/summarized-rangerdistrict.js
+++ b/src/controllers/summarized-rangerdistrict.js
@@ -126,7 +126,7 @@ export const getByFilter = async (startYear, endYear, state, rangerDistrict, pag
   const parsedLimit = Math.min(5000, Math.max(1, parseInt(limit, 10) || 1000)); // max 5000 per page
 
   const skip = (parsedPage - 1) * parsedLimit;
-  const total = await query.countDocuments();
+  const total = await query.model.countDocuments(query.getFilter());
 
   const data = await query
     .sort({

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -133,10 +133,12 @@ export const uploadCsv = async (filename) => {
   const insertOp = bulkOp.filter(({ insertOne }) => !!insertOne);
   const deleteOp = bulkOp.filter(({ deleteMany }) => !!deleteMany);
 
-  const deleteRes = await UnsummarizedTrappingModel.bulkWrite(deleteOp, { ordered: false });
-  const insertRes = await UnsummarizedTrappingModel.bulkWrite(insertOp, { ordered: false });
-
-  console.log(`successfully parsed ${rowCount} rows from csv upload`);
+  const deleteRes = deleteOp.length
+    ? await UnsummarizedTrappingModel.bulkWrite(deleteOp, { ordered: false })
+    : { deletedCount: 0 };
+  const insertRes = insertOp.length
+    ? await UnsummarizedTrappingModel.bulkWrite(insertOp, { ordered: false })
+    : { insertedCount: 0 };
 
   // run entire pipeline
   // don't throw the error here since we want to return 200 immediately

--- a/src/controllers/unsummarized-trapping.js
+++ b/src/controllers/unsummarized-trapping.js
@@ -104,7 +104,7 @@ export const getByFilter = async (startYear, endYear, state, county, rangerDistr
   const parsedLimit = Math.min(5000, Math.max(1, parseInt(limit, 10) || 1000)); // max 5000 per page
 
   const skip = (parsedPage - 1) * parsedLimit;
-  const total = await query.countDocuments();
+  const total = await query.model.countDocuments(query.getFilter());
 
   const data = await query
     .sort({

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { Router } from 'express';
 import multer from 'multer';
 
@@ -17,6 +18,15 @@ const upload = multer({ dest: './uploads' });
 
 const survey123Router = Router();
 
+// In-memory store for async upload statuses
+const uploadStatuses = new Map();
+
+// Clean up completed statuses after 30 minutes
+const STATUS_TTL_MS = 30 * 60 * 1000;
+const cleanupStatus = (uploadId) => {
+  setTimeout(() => uploadStatuses.delete(uploadId), STATUS_TTL_MS);
+};
+
 survey123Router.route('/upload')
   .post(requireAuth, upload.single('csv'), async (req, res) => {
     if (!req.file) {
@@ -25,22 +35,61 @@ survey123Router.route('/upload')
     }
 
     const filePath = req.file.path;
-    try {
-      const result = await Survey123.uploadCsv(filePath);
-      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
-        message: 'CSV imported successfully. Pipeline has been started.',
-        rowsProcessed: result.rowCount,
-        inserted: result.insertRes?.insertedCount ?? 0,
-        deleted: result.deleteRes?.deletedCount ?? 0,
+    const uploadId = crypto.randomUUID();
+
+    uploadStatuses.set(uploadId, { status: 'processing' });
+
+    // Return 202 immediately to avoid Heroku 30s H12 timeout
+    res.status(202).send(generateResponse(RESPONSE_TYPES.SUCCESS, { uploadId }));
+
+    // Process CSV in background
+    console.log(`[survey123] starting background upload for ${uploadId}`);
+    Survey123.uploadCsv(filePath)
+      .then((result) => {
+        console.log(`[survey123] upload ${uploadId} completed successfully`);
+        uploadStatuses.set(uploadId, {
+          status: 'success',
+          message: `CSV imported successfully. ${result.rowCount} rows processed, ${result.insertRes?.insertedCount ?? 0} inserted, ${result.deleteRes?.deletedCount ?? 0} deleted. Pipeline has been started.`,
+        });
+        cleanupStatus(uploadId);
+      })
+      .catch((err) => {
+        console.error(`[survey123] upload ${uploadId} FAILED:`, err);
+        const errorResponse = generateErrorResponse(err);
+        uploadStatuses.set(uploadId, {
+          status: 'error',
+          message: errorResponse.error || 'Upload failed',
+        });
+        cleanupStatus(uploadId);
+      })
+      .finally(() => {
+        setTimeout(() => deleteFile(filePath), 1000 * 10);
+      });
+  });
+
+survey123Router.route('/upload/status')
+  .get(requireAuth, (req, res) => {
+    const { uploadId } = req.query;
+
+    if (!uploadId) {
+      res.status(400).send(generateErrorResponse({
+        type: RESPONSE_TYPES.BAD_REQUEST,
+        message: 'missing uploadId',
       }));
-    } catch (err) {
-      const errorResponse = generateErrorResponse(err);
-      const { error: errorMessage, status } = errorResponse;
-      console.error('csv upload failed:', errorMessage);
-      res.status(status).send(errorResponse);
-    } finally {
-      setTimeout(() => deleteFile(filePath), 1000 * 10);
+      return;
     }
+
+    const statusData = uploadStatuses.get(uploadId);
+
+    if (!statusData) {
+      res.status(404).send(generateErrorResponse({
+        type: RESPONSE_TYPES.NOT_FOUND,
+        message: 'Upload not found or expired',
+      }));
+      return;
+    }
+
+    res.send(generateResponse(RESPONSE_TYPES.SUCCESS, statusData));
   });
 
 survey123Router.route('/webhook')

--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -33,12 +33,31 @@ export const deleteFile = async (filename, isAbsolutePath) => {
 export const processCSV = (filename, transformRow = (r) => r) => {
   const filepath = path.resolve(__dirname, `../../${filename}`);
   const docs = [];
+  let failed = false;
 
   return new Promise((resolve, reject) => {
-    parseFile(filepath, { headers: true })
-      .on('data', (data) => docs.push(transformRow(data)))
-      .on('error', (err) => reject(err))
-      .on('end', (rowCount) => resolve({ docs, rowCount }));
+    const stream = parseFile(filepath, { headers: true });
+
+    stream
+      .on('data', (data) => {
+        if (failed) return;
+        try {
+          docs.push(transformRow(data));
+        } catch (err) {
+          failed = true;
+          stream.destroy();
+          reject(err);
+        }
+      })
+      .on('error', (err) => {
+        if (!failed) {
+          failed = true;
+          reject(err);
+        }
+      })
+      .on('end', (rowCount) => {
+        if (!failed) resolve({ docs, rowCount });
+      });
   });
 };
 


### PR DESCRIPTION
# Description

Make survey123 CSV upload async with status polling to prevent Heroku H12 timeout. Also fix bulkWrite hanging on empty arrays, processCSV error handling, and countDocuments query reuse bug.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)
