### PR TITLE
Raise daysActive upper bound from 60 to 90 in Survey123 CSV upload

### DIFF
--- a/src/utils/survey123.js
+++ b/src/utils/survey123.js
@@ -27,8 +27,9 @@ export const deleteInsert = (sixWeeksData) => {
     acc + (parseInt(curr.daysActive, 10) || 0)
   ), 0);
 
-  // only insert if data is valid and between 12 and 60 days total active
-  const insertOps = shouldInsert && numDaysActive >= 12 && numDaysActive <= 60
+  // only insert if data is valid and between 12 and 90 days total active
+  // upper bound 90 covers full 6-week spring surveys spanning ~Mar-May (typically 60-70 days)
+  const insertOps = shouldInsert && numDaysActive >= 12 && numDaysActive <= 90
     ? sixWeeksData.map((weekData) => ({
       insertOne: {
         document: weekData,


### PR DESCRIPTION
## Summary

The `deleteInsert` validator in `src/utils/survey123.js` silently rejected any survey whose cumulative `TrappingInterval` across all 6 weeks exceeded **60 days**. Six-week spring surveys running March → May naturally total 60–70 days, so legitimate uploads were dropped without surfacing any error to the admin tool.

This PR raises the upper bound from 60 → 90. The lower bound (12 days) is unchanged — still protects against truly broken data.

## Why this matters

Wayne and Houston counties (Georgia, 2026) failed to appear on the prediction map. The admin CSV upload tool returned a 200, but only the `deleteMany` op ran — no inserts. With no rows in `unsummarizedtrappings`, the downstream summarization, spot-projection, and prediction steps had nothing to act on.

- **Houston**: 7 + 12 + 13 + 9 + 7 + 13 = **61 days** → rejected
- **Wayne**: 7 + 7 + 21 + 21 + 9 = **65 days** → rejected
- All other GA counties came in ≤ 60 → passed

## Change

```diff
- // only insert if data is valid and between 12 and 60 days total active
- const insertOps = shouldInsert && numDaysActive >= 12 && numDaysActive <= 60
+ // only insert if data is valid and between 12 and 90 days total active
+ // upper bound 90 covers full 6-week spring surveys spanning ~Mar-May (typically 60-70 days)
+ const insertOps = shouldInsert && numDaysActive >= 12 && numDaysActive <= 90
```

## Test plan

- [ ] Deploy to dev
- [ ] Re-upload the original `GA_HouWay_CORR.csv` (no edits) via the admin tool
- [ ] Confirm both counties appear in `unsummarizedtrappings`
- [ ] After pipeline run, confirm `summarizedcounties` has 2026 rows with `hasSPBTrapping=1` for Houston and Wayne (`GET /v3/summarized-county/?state=GA&county=Houston&year=2026`)
- [ ] Confirm `isValidForPrediction=1` (verifies `spotst1` / `spotst2` populate from existing 2024/2025 spot data)
- [ ] Confirm both counties render on the 2026 prediction map in the frontend
- [ ] Spot-check one previously-working GA county (e.g. Bibb) to confirm no regression

## Notes

- Backward compatible: any survey that passed before (≤ 60 days) still passes.
- No schema or migration changes.
- Validation lower bound left at 12 — unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/pine-beetle-automation/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782036859&installation_id=133523038&pr_number=217&repository=dali-lab%2Fpine-beetle-automation&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fpine-beetle-automation%2Fpull%2F217&signature=509eec1687471ece3e91d45c0327e634b842de936e0224712f753cb833ca3372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->