### PR TITLE
Add CSV upload preview, rejection tracking, and audit log

### DIFF
--- a/src/controllers/summarized-county.js
+++ b/src/controllers/summarized-county.js
@@ -22,6 +22,7 @@ import {
   processCSV,
   processCSVAsync,
   trappingAggregationPipelineCreator,
+  tryCastNumber,
   upsertOpCreator,
   validateNumberEntry,
 } from '../utils';
@@ -263,26 +264,110 @@ const cleanCsv = (row) => {
   };
 };
 
+const buildCountyIdentifier = (row, rowNumber) => (
+  `row ${rowNumber} / ${row.state || '?'} / ${row.county || '?'} / ${row.year || '?'}`
+);
+
+// pre-validate every numeric attribute the same way mongoose would at bulkWrite time
+const collectNumericRejections = (row, identifier, rowNumber) => {
+  const out = [];
+  numericModelAttributes.forEach((field) => {
+    const raw = row[field];
+    if (raw === undefined || raw === null || raw === '') return;
+    if (!tryCastNumber(raw).ok) {
+      out.push({
+        rowNumber,
+        identifier,
+        reason: 'INVALID_NUMERIC',
+        field,
+        value: String(raw),
+      });
+    }
+  });
+  return out;
+};
+
+/**
+ * @description parses + validates the summarized-county CSV without writing to DB
+ */
+export const parseCountyCsv = async (filename) => {
+  const rejected = [];
+
+  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => {
+    const cleanedData = extractModelAttributes(cleanCsv(row));
+    const identifier = buildCountyIdentifier(row, rowNumber);
+
+    // pre-validate cast-ability for every numeric field — surfaces what
+    // would otherwise be a silent CastError at bulkWrite time
+    const castIssues = collectNumericRejections(cleanedData, identifier, rowNumber);
+    if (castIssues.length > 0) {
+      rejected.push(...castIssues);
+      return null;
+    }
+
+    return cleanedData;
+  }, { collectErrors: true });
+
+  rejections.forEach(({ rowNumber, error, raw }) => {
+    rejected.push({
+      rowNumber,
+      identifier: buildCountyIdentifier(raw, rowNumber),
+      reason: 'MISSING_REQUIRED_FIELD',
+      field: error?.message || '',
+    });
+  });
+
+  const validDocs = docs.filter((d) => !!d);
+  const upsertOperations = validDocs.map(upsertOp);
+
+  return {
+    rowCount,
+    upsertOperations,
+    accepted: validDocs.length,
+    skipped: [],
+    rejected,
+  };
+};
+
 /**
  * @description uploads a csv to the summarized county collection
  * @param {String} filename the csv filename on disk
+ * @param {Object} [options]
+ * @param {Boolean} [options.dryRun=false]
  * @throws RESPONSE_TYPES.BAD_REQUEST for missing fields
  * @throws other errors depending on what went wrong
  */
-export const uploadCsv = async (filename) => {
-  const { docs, rowCount } = await processCSV(filename, (row) => {
-    // cast the csv fields to our schema
-    const cleanedData = extractModelAttributes(cleanCsv(row));
+export const uploadCsv = async (filename, options = {}) => {
+  const { dryRun = false } = options;
+  const parsed = await parseCountyCsv(filename);
 
-    return cleanedData;
-  });
+  if (dryRun) {
+    return {
+      rowCount: parsed.rowCount,
+      accepted: parsed.accepted,
+      skippedRows: 0,
+      rejectedRows: parsed.rejected.length,
+      skipped: [],
+      rejected: parsed.rejected,
+      bulkWriteResult: null,
+    };
+  }
 
-  // apply another transformation to prepare for upserting
-  const upsertOperations = docs.map(upsertOp);
-  const bulkWriteResult = await SummarizedCountyModel.bulkWrite(upsertOperations);
+  const bulkWriteResult = parsed.upsertOperations.length
+    ? await SummarizedCountyModel.bulkWrite(parsed.upsertOperations)
+    : null;
 
-  console.log(`successfully parsed ${rowCount} rows from csv upload`);
-  return bulkWriteResult;
+  console.log(`successfully parsed ${parsed.rowCount} rows from csv upload`);
+
+  return {
+    rowCount: parsed.rowCount,
+    accepted: parsed.accepted,
+    skippedRows: 0,
+    rejectedRows: parsed.rejected.length,
+    skipped: [],
+    rejected: parsed.rejected,
+    bulkWriteResult,
+  };
 };
 
 /**
@@ -307,31 +392,97 @@ const cleanSpotsCsv = (row) => {
 };
 
 /**
- * @description uploads a csv with spot data to the summarized county collection
- * @param {String} filename the csv filename on disk
- * @throws RESPONSE_TYPES.BAD_REQUEST for missing fields
- * @throws other errors depending on what went wrong
+ * @description parses + validates the spots CSV without writing to DB
  */
-export const uploadSpotsCsv = async (filename) => {
-  const { docs, rowCount } = await processCSVAsync(filename, async (row) => {
-    // cast the csv fields to our schema
-    const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
+export const parseCountySpotsCsv = async (filename) => {
+  const rejected = [];
 
-    // explicitly look up and set endobrev value for this document
+  const { docs, rowCount, rejections } = await processCSVAsync(filename, async (row, rowNumber) => {
+    const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
+    const identifier = buildCountyIdentifier(row, rowNumber);
+
+    // validate spotst0 + year cast — these are the only numerics here
+    if (!tryCastNumber(cleanedData.spotst0).ok) {
+      rejected.push({
+        rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'spotst0', value: String(cleanedData.spotst0),
+      });
+      return null;
+    }
+    if (cleanedData.year !== undefined && cleanedData.year !== '' && !tryCastNumber(cleanedData.year).ok) {
+      rejected.push({
+        rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'year', value: String(cleanedData.year),
+      });
+      return null;
+    }
+
     const { county, state, year } = cleanedData;
 
     const matchingDoc = await SummarizedCountyModel.findOne({ state, year, county });
     const endobrev = matchingDoc?.endobrev || null;
 
     return { ...cleanedData, endobrev };
+  }, { collectErrors: true });
+
+  rejections.forEach(({ rowNumber, error, raw }) => {
+    rejected.push({
+      rowNumber,
+      identifier: buildCountyIdentifier(raw, rowNumber),
+      reason: 'MISSING_REQUIRED_FIELD',
+      field: error?.message || '',
+    });
   });
 
-  // apply another transformation to prepare for upserting
-  const upsertOperations = docs.map(upsertOp);
-  const bulkWriteResult = await SummarizedCountyModel.bulkWrite(upsertOperations);
+  const validDocs = docs.filter((d) => !!d);
+  const upsertOperations = validDocs.map(upsertOp);
 
-  console.log(`successfully parsed ${rowCount} rows from csv upload`);
-  return bulkWriteResult;
+  return {
+    rowCount,
+    upsertOperations,
+    accepted: validDocs.length,
+    skipped: [],
+    rejected,
+  };
+};
+
+/**
+ * @description uploads a csv with spot data to the summarized county collection
+ * @param {String} filename the csv filename on disk
+ * @param {Object} [options]
+ * @param {Boolean} [options.dryRun=false]
+ * @throws RESPONSE_TYPES.BAD_REQUEST for missing fields
+ * @throws other errors depending on what went wrong
+ */
+export const uploadSpotsCsv = async (filename, options = {}) => {
+  const { dryRun = false } = options;
+  const parsed = await parseCountySpotsCsv(filename);
+
+  if (dryRun) {
+    return {
+      rowCount: parsed.rowCount,
+      accepted: parsed.accepted,
+      skippedRows: 0,
+      rejectedRows: parsed.rejected.length,
+      skipped: [],
+      rejected: parsed.rejected,
+      bulkWriteResult: null,
+    };
+  }
+
+  const bulkWriteResult = parsed.upsertOperations.length
+    ? await SummarizedCountyModel.bulkWrite(parsed.upsertOperations)
+    : null;
+
+  console.log(`successfully parsed ${parsed.rowCount} rows from csv upload`);
+
+  return {
+    rowCount: parsed.rowCount,
+    accepted: parsed.accepted,
+    skippedRows: 0,
+    rejectedRows: parsed.rejected.length,
+    skipped: [],
+    rejected: parsed.rejected,
+    bulkWriteResult,
+  };
 };
 
 /**

--- a/src/controllers/summarized-county.js
+++ b/src/controllers/summarized-county.js
@@ -296,6 +296,19 @@ export const parseCountyCsv = async (filename) => {
     const cleanedData = extractModelAttributes(cleanCsv(row));
     const identifier = buildCountyIdentifier(row, rowNumber);
 
+    // Required key fields cannot be blank — mongoose's global '' → 0 cast (for year)
+    // and '' → null cast (for state/county) would otherwise silently corrupt the
+    // compound unique index.
+    const missingKeys = ['state', 'year', 'county'].filter((f) => (
+      cleanedData[f] === undefined || cleanedData[f] === null || cleanedData[f] === ''
+    ));
+    if (missingKeys.length > 0) {
+      rejected.push({
+        rowNumber, identifier, reason: 'MISSING_REQUIRED_FIELD', field: missingKeys.join(','),
+      });
+      return null;
+    }
+
     // pre-validate cast-ability for every numeric field — surfaces what
     // would otherwise be a silent CastError at bulkWrite time
     const castIssues = collectNumericRejections(cleanedData, identifier, rowNumber);
@@ -403,6 +416,19 @@ export const parseCountySpotsCsv = async (filename) => {
     const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
     const identifier = buildCountyIdentifier(row, rowNumber);
 
+    // Required key fields cannot be blank — mongoose's global '' → 0 cast (for year)
+    // and '' → null cast (for state/county) would otherwise silently corrupt the
+    // compound unique index {year, state, county, endobrev}.
+    const missingKeys = ['state', 'year', 'county'].filter((f) => (
+      cleanedData[f] === undefined || cleanedData[f] === null || cleanedData[f] === ''
+    ));
+    if (missingKeys.length > 0) {
+      rejected.push({
+        rowNumber, identifier, reason: 'MISSING_REQUIRED_FIELD', field: missingKeys.join(','),
+      });
+      return null;
+    }
+
     // validate spotst0 + year cast — these are the only numerics here
     if (!tryCastNumber(cleanedData.spotst0).ok) {
       rejected.push({
@@ -410,7 +436,7 @@ export const parseCountySpotsCsv = async (filename) => {
       });
       return null;
     }
-    if (cleanedData.year !== undefined && cleanedData.year !== '' && !tryCastNumber(cleanedData.year).ok) {
+    if (!tryCastNumber(cleanedData.year).ok) {
       rejected.push({
         rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'year', value: String(cleanedData.year),
       });
@@ -446,7 +472,7 @@ export const parseCountySpotsCsv = async (filename) => {
 
   const validDocs = validRows.map((d) => ({
     ...d,
-    endobrev: endobrevByKey.get(countySpotKey(d)) || null,
+    endobrev: endobrevByKey.has(countySpotKey(d)) ? endobrevByKey.get(countySpotKey(d)) : null,
   }));
   const upsertOperations = validDocs.map(upsertOp);
 

--- a/src/controllers/summarized-county.js
+++ b/src/controllers/summarized-county.js
@@ -20,7 +20,6 @@ import {
   offsetYearPassCreator,
   predictionGeneratorCreator,
   processCSV,
-  processCSVAsync,
   trappingAggregationPipelineCreator,
   tryCastNumber,
   upsertOpCreator,
@@ -345,6 +344,7 @@ export const uploadCsv = async (filename, options = {}) => {
     return {
       rowCount: parsed.rowCount,
       accepted: parsed.accepted,
+      willDelete: 0,
       skippedRows: 0,
       rejectedRows: parsed.rejected.length,
       skipped: [],
@@ -394,10 +394,12 @@ const cleanSpotsCsv = (row) => {
 /**
  * @description parses + validates the spots CSV without writing to DB
  */
+const countySpotKey = (d) => `${d.state}|${d.year}|${d.county}`;
+
 export const parseCountySpotsCsv = async (filename) => {
   const rejected = [];
 
-  const { docs, rowCount, rejections } = await processCSVAsync(filename, async (row, rowNumber) => {
+  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => {
     const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
     const identifier = buildCountyIdentifier(row, rowNumber);
 
@@ -415,12 +417,7 @@ export const parseCountySpotsCsv = async (filename) => {
       return null;
     }
 
-    const { county, state, year } = cleanedData;
-
-    const matchingDoc = await SummarizedCountyModel.findOne({ state, year, county });
-    const endobrev = matchingDoc?.endobrev || null;
-
-    return { ...cleanedData, endobrev };
+    return cleanedData; // endobrev attached after a single batched lookup below
   }, { collectErrors: true });
 
   rejections.forEach(({ rowNumber, error, raw }) => {
@@ -432,7 +429,25 @@ export const parseCountySpotsCsv = async (filename) => {
     });
   });
 
-  const validDocs = docs.filter((d) => !!d);
+  const validRows = docs.filter((d) => !!d);
+
+  // resolve endobrev for every row in ONE query instead of findOne-per-row
+  const endobrevByKey = new Map();
+  if (validRows.length) {
+    const uniqueKeys = [...new Map(
+      validRows.map((d) => [countySpotKey(d), { state: d.state, year: d.year, county: d.county }]),
+    ).values()];
+    const matches = await SummarizedCountyModel
+      .find({ $or: uniqueKeys })
+      .select('state year county endobrev')
+      .lean();
+    matches.forEach((m) => endobrevByKey.set(countySpotKey(m), m.endobrev));
+  }
+
+  const validDocs = validRows.map((d) => ({
+    ...d,
+    endobrev: endobrevByKey.get(countySpotKey(d)) || null,
+  }));
   const upsertOperations = validDocs.map(upsertOp);
 
   return {
@@ -460,6 +475,7 @@ export const uploadSpotsCsv = async (filename, options = {}) => {
     return {
       rowCount: parsed.rowCount,
       accepted: parsed.accepted,
+      willDelete: 0,
       skippedRows: 0,
       rejectedRows: parsed.rejected.length,
       skipped: [],

--- a/src/controllers/summarized-rangerdistrict.js
+++ b/src/controllers/summarized-rangerdistrict.js
@@ -24,7 +24,6 @@ import {
   offsetYearPassCreator,
   predictionGeneratorCreator,
   processCSV,
-  processCSVAsync,
   trappingAggregationPipelineCreator,
   tryCastNumber,
   upsertOpCreator,
@@ -329,6 +328,7 @@ export const uploadCsv = async (filename, options = {}) => {
     return {
       rowCount: parsed.rowCount,
       accepted: parsed.accepted,
+      willDelete: 0,
       skippedRows: 0,
       rejectedRows: parsed.rejected.length,
       skipped: [],
@@ -378,10 +378,12 @@ const cleanSpotsCsv = (row) => {
 /**
  * @description parses + validates the spots CSV without writing to DB
  */
+const rdSpotKey = (d) => `${d.state}|${d.year}|${d.rangerDistrict}`;
+
 export const parseRdSpotsCsv = async (filename) => {
   const rejected = [];
 
-  const { docs, rowCount, rejections } = await processCSVAsync(filename, async (row, rowNumber) => {
+  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => {
     const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
     const identifier = buildRdIdentifier(row, rowNumber);
 
@@ -398,12 +400,7 @@ export const parseRdSpotsCsv = async (filename) => {
       return null;
     }
 
-    const { rangerDistrict, state, year } = cleanedData;
-
-    const matchingDoc = await SummarizedRangerDistrictModel.findOne({ state, year, rangerDistrict });
-    const endobrev = matchingDoc?.endobrev || null;
-
-    return { ...cleanedData, endobrev };
+    return cleanedData; // endobrev attached after a single batched lookup below
   }, { collectErrors: true });
 
   rejections.forEach(({ rowNumber, error, raw }) => {
@@ -415,7 +412,25 @@ export const parseRdSpotsCsv = async (filename) => {
     });
   });
 
-  const validDocs = docs.filter((d) => !!d);
+  const validRows = docs.filter((d) => !!d);
+
+  // resolve endobrev for every row in ONE query instead of findOne-per-row
+  const endobrevByKey = new Map();
+  if (validRows.length) {
+    const uniqueKeys = [...new Map(
+      validRows.map((d) => [rdSpotKey(d), { state: d.state, year: d.year, rangerDistrict: d.rangerDistrict }]),
+    ).values()];
+    const matches = await SummarizedRangerDistrictModel
+      .find({ $or: uniqueKeys })
+      .select('state year rangerDistrict endobrev')
+      .lean();
+    matches.forEach((m) => endobrevByKey.set(rdSpotKey(m), m.endobrev));
+  }
+
+  const validDocs = validRows.map((d) => ({
+    ...d,
+    endobrev: endobrevByKey.get(rdSpotKey(d)) || null,
+  }));
   const upsertOperations = validDocs.map(upsertOp);
 
   return {
@@ -443,6 +458,7 @@ export const uploadSpotsCsv = async (filename, options = {}) => {
     return {
       rowCount: parsed.rowCount,
       accepted: parsed.accepted,
+      willDelete: 0,
       skippedRows: 0,
       rejectedRows: parsed.rejected.length,
       skipped: [],

--- a/src/controllers/summarized-rangerdistrict.js
+++ b/src/controllers/summarized-rangerdistrict.js
@@ -283,6 +283,19 @@ export const parseRdCsv = async (filename) => {
     const cleanedData = extractModelAttributes(cleanCsv(row));
     const identifier = buildRdIdentifier(row, rowNumber);
 
+    // Required key fields cannot be blank — mongoose's global '' → 0 cast (for year)
+    // and '' → null cast (for state/rangerDistrict) would otherwise silently corrupt
+    // the compound unique index.
+    const missingKeys = ['state', 'year', 'rangerDistrict'].filter((f) => (
+      cleanedData[f] === undefined || cleanedData[f] === null || cleanedData[f] === ''
+    ));
+    if (missingKeys.length > 0) {
+      rejected.push({
+        rowNumber, identifier, reason: 'MISSING_REQUIRED_FIELD', field: missingKeys.join(','),
+      });
+      return null;
+    }
+
     const castIssues = collectRdNumericRejections(cleanedData, identifier, rowNumber);
     if (castIssues.length > 0) {
       rejected.push(...castIssues);
@@ -387,13 +400,26 @@ export const parseRdSpotsCsv = async (filename) => {
     const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
     const identifier = buildRdIdentifier(row, rowNumber);
 
+    // Required key fields cannot be blank — mongoose's global '' → 0 cast (for year)
+    // and '' → null cast (for state/rangerDistrict) would otherwise silently corrupt
+    // the compound unique index {year, state, rangerDistrict, endobrev}.
+    const missingKeys = ['state', 'year', 'rangerDistrict'].filter((f) => (
+      cleanedData[f] === undefined || cleanedData[f] === null || cleanedData[f] === ''
+    ));
+    if (missingKeys.length > 0) {
+      rejected.push({
+        rowNumber, identifier, reason: 'MISSING_REQUIRED_FIELD', field: missingKeys.join(','),
+      });
+      return null;
+    }
+
     if (!tryCastNumber(cleanedData.spotst0).ok) {
       rejected.push({
         rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'spotst0', value: String(cleanedData.spotst0),
       });
       return null;
     }
-    if (cleanedData.year !== undefined && cleanedData.year !== '' && !tryCastNumber(cleanedData.year).ok) {
+    if (!tryCastNumber(cleanedData.year).ok) {
       rejected.push({
         rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'year', value: String(cleanedData.year),
       });
@@ -429,7 +455,7 @@ export const parseRdSpotsCsv = async (filename) => {
 
   const validDocs = validRows.map((d) => ({
     ...d,
-    endobrev: endobrevByKey.get(rdSpotKey(d)) || null,
+    endobrev: endobrevByKey.has(rdSpotKey(d)) ? endobrevByKey.get(rdSpotKey(d)) : null,
   }));
   const upsertOperations = validDocs.map(upsertOp);
 

--- a/src/controllers/summarized-rangerdistrict.js
+++ b/src/controllers/summarized-rangerdistrict.js
@@ -26,6 +26,7 @@ import {
   processCSV,
   processCSVAsync,
   trappingAggregationPipelineCreator,
+  tryCastNumber,
   upsertOpCreator,
   validateNumberEntry,
 } from '../utils';
@@ -251,26 +252,106 @@ const cleanCsv = (row) => {
   };
 };
 
+const buildRdIdentifier = (row, rowNumber) => (
+  `row ${rowNumber} / ${row.state || '?'} / ${row.rangerDistrict || '?'} / ${row.year || '?'}`
+);
+
+const collectRdNumericRejections = (row, identifier, rowNumber) => {
+  const out = [];
+  numericModelAttributes.forEach((field) => {
+    const raw = row[field];
+    if (raw === undefined || raw === null || raw === '') return;
+    if (!tryCastNumber(raw).ok) {
+      out.push({
+        rowNumber,
+        identifier,
+        reason: 'INVALID_NUMERIC',
+        field,
+        value: String(raw),
+      });
+    }
+  });
+  return out;
+};
+
+/**
+ * @description parses + validates the summarized-rangerdistrict CSV without writing to DB
+ */
+export const parseRdCsv = async (filename) => {
+  const rejected = [];
+
+  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => {
+    const cleanedData = extractModelAttributes(cleanCsv(row));
+    const identifier = buildRdIdentifier(row, rowNumber);
+
+    const castIssues = collectRdNumericRejections(cleanedData, identifier, rowNumber);
+    if (castIssues.length > 0) {
+      rejected.push(...castIssues);
+      return null;
+    }
+    return cleanedData;
+  }, { collectErrors: true });
+
+  rejections.forEach(({ rowNumber, error, raw }) => {
+    rejected.push({
+      rowNumber,
+      identifier: buildRdIdentifier(raw, rowNumber),
+      reason: 'MISSING_REQUIRED_FIELD',
+      field: error?.message || '',
+    });
+  });
+
+  const validDocs = docs.filter((d) => !!d);
+  const upsertOperations = validDocs.map(upsertOp);
+
+  return {
+    rowCount,
+    upsertOperations,
+    accepted: validDocs.length,
+    skipped: [],
+    rejected,
+  };
+};
+
 /**
  * @description uploads a csv to the summarized ranger district collection
  * @param {String} filename the csv filename on disk
+ * @param {Object} [options]
+ * @param {Boolean} [options.dryRun=false]
  * @throws RESPONSE_TYPES.BAD_REQUEST for missing fields
  * @throws other errors depending on what went wrong
  */
-export const uploadCsv = async (filename) => {
-  const { docs, rowCount } = await processCSV(filename, (row) => {
-    // cast the csv fields to our schema
-    const cleanedData = extractModelAttributes(cleanCsv(row));
+export const uploadCsv = async (filename, options = {}) => {
+  const { dryRun = false } = options;
+  const parsed = await parseRdCsv(filename);
 
-    return cleanedData;
-  });
+  if (dryRun) {
+    return {
+      rowCount: parsed.rowCount,
+      accepted: parsed.accepted,
+      skippedRows: 0,
+      rejectedRows: parsed.rejected.length,
+      skipped: [],
+      rejected: parsed.rejected,
+      bulkWriteResult: null,
+    };
+  }
 
-  // apply another transformation to prepare for upserting
-  const upsertOperations = docs.map(upsertOp);
-  const bulkWriteResult = await SummarizedRangerDistrictModel.bulkWrite(upsertOperations);
+  const bulkWriteResult = parsed.upsertOperations.length
+    ? await SummarizedRangerDistrictModel.bulkWrite(parsed.upsertOperations)
+    : null;
 
-  console.log(`successfully parsed ${rowCount} rows from csv upload`);
-  return bulkWriteResult;
+  console.log(`successfully parsed ${parsed.rowCount} rows from csv upload`);
+
+  return {
+    rowCount: parsed.rowCount,
+    accepted: parsed.accepted,
+    skippedRows: 0,
+    rejectedRows: parsed.rejected.length,
+    skipped: [],
+    rejected: parsed.rejected,
+    bulkWriteResult,
+  };
 };
 
 /**
@@ -295,31 +376,96 @@ const cleanSpotsCsv = (row) => {
 };
 
 /**
- * @description uploads a csv with spot data to the summarized county collection
- * @param {String} filename the csv filename on disk
- * @throws RESPONSE_TYPES.BAD_REQUEST for missing fields
- * @throws other errors depending on what went wrong
+ * @description parses + validates the spots CSV without writing to DB
  */
-export const uploadSpotsCsv = async (filename) => {
-  const { docs, rowCount } = await processCSVAsync(filename, async (row) => {
-    // cast the csv fields to our schema
-    const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
+export const parseRdSpotsCsv = async (filename) => {
+  const rejected = [];
 
-    // explicitly look up and set endobrev value for this document
+  const { docs, rowCount, rejections } = await processCSVAsync(filename, async (row, rowNumber) => {
+    const cleanedData = extractObjectFieldsCreator(spotAttributes)(cleanSpotsCsv(row));
+    const identifier = buildRdIdentifier(row, rowNumber);
+
+    if (!tryCastNumber(cleanedData.spotst0).ok) {
+      rejected.push({
+        rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'spotst0', value: String(cleanedData.spotst0),
+      });
+      return null;
+    }
+    if (cleanedData.year !== undefined && cleanedData.year !== '' && !tryCastNumber(cleanedData.year).ok) {
+      rejected.push({
+        rowNumber, identifier, reason: 'INVALID_NUMERIC', field: 'year', value: String(cleanedData.year),
+      });
+      return null;
+    }
+
     const { rangerDistrict, state, year } = cleanedData;
 
     const matchingDoc = await SummarizedRangerDistrictModel.findOne({ state, year, rangerDistrict });
     const endobrev = matchingDoc?.endobrev || null;
 
     return { ...cleanedData, endobrev };
+  }, { collectErrors: true });
+
+  rejections.forEach(({ rowNumber, error, raw }) => {
+    rejected.push({
+      rowNumber,
+      identifier: buildRdIdentifier(raw, rowNumber),
+      reason: 'MISSING_REQUIRED_FIELD',
+      field: error?.message || '',
+    });
   });
 
-  // apply another transformation to prepare for upserting
-  const upsertOperations = docs.map(upsertOp);
-  const bulkWriteResult = await SummarizedRangerDistrictModel.bulkWrite(upsertOperations);
+  const validDocs = docs.filter((d) => !!d);
+  const upsertOperations = validDocs.map(upsertOp);
 
-  console.log(`successfully parsed ${rowCount} rows from csv upload`);
-  return bulkWriteResult;
+  return {
+    rowCount,
+    upsertOperations,
+    accepted: validDocs.length,
+    skipped: [],
+    rejected,
+  };
+};
+
+/**
+ * @description uploads a csv with spot data to the summarized county collection
+ * @param {String} filename the csv filename on disk
+ * @param {Object} [options]
+ * @param {Boolean} [options.dryRun=false]
+ * @throws RESPONSE_TYPES.BAD_REQUEST for missing fields
+ * @throws other errors depending on what went wrong
+ */
+export const uploadSpotsCsv = async (filename, options = {}) => {
+  const { dryRun = false } = options;
+  const parsed = await parseRdSpotsCsv(filename);
+
+  if (dryRun) {
+    return {
+      rowCount: parsed.rowCount,
+      accepted: parsed.accepted,
+      skippedRows: 0,
+      rejectedRows: parsed.rejected.length,
+      skipped: [],
+      rejected: parsed.rejected,
+      bulkWriteResult: null,
+    };
+  }
+
+  const bulkWriteResult = parsed.upsertOperations.length
+    ? await SummarizedRangerDistrictModel.bulkWrite(parsed.upsertOperations)
+    : null;
+
+  console.log(`successfully parsed ${parsed.rowCount} rows from csv upload`);
+
+  return {
+    rowCount: parsed.rowCount,
+    accepted: parsed.accepted,
+    skippedRows: 0,
+    rejectedRows: parsed.rejected.length,
+    skipped: [],
+    rejected: parsed.rejected,
+    bulkWriteResult,
+  };
 };
 
 /**

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -170,6 +170,10 @@ export const parseSurvey123Csv = async (filename) => {
         throw newError(RESPONSE_TYPES.BAD_REQUEST, `missing fields: ${missingFields}`);
       }
 
+      const shouldDeleteSurvey = sixWeekData[deleteField] === 'yes';
+      const isFinalCollection = sixWeekData.Is_Final_Collection === 'yes';
+      const shouldInsert = !shouldDeleteSurvey && isFinalCollection;
+
       if (!cleanedData.collectionDate) {
         skipped.push({
           rowNumber, identifier: `${identifier} / week ${weekNum}`, reason: SURVEY123_REASONS.MISSING_COLLECTION_DATE,
@@ -183,12 +187,28 @@ export const parseSurvey123Csv = async (filename) => {
         return undefined;
       }
 
-      // numeric/date cast checks — would otherwise throw at bulkWrite time
-      const castOk = validateCastable(cleanedData, `${identifier} / week ${weekNum}`, rowNumber, rejected);
-      if (!castOk) return undefined;
+      // numeric/date cast checks — only block insertion. For delete-marked rows we still
+      // want the deleteMany to fire even if old data has garbage numerics that triggered
+      // the user to delete the survey in the first place.
+      if (shouldInsert) {
+        // Required key fields cannot be blank — mongoose's global '' → 0 cast (for year)
+        // and '' → null cast (for state) would otherwise silently corrupt the row.
+        const missingKeys = ['state', 'year'].filter((f) => (
+          cleanedData[f] === undefined || cleanedData[f] === null || cleanedData[f] === ''
+        ));
+        if (missingKeys.length > 0) {
+          rejected.push({
+            rowNumber,
+            identifier: `${identifier} / week ${weekNum}`,
+            reason: SURVEY123_REASONS.MISSING_REQUIRED_FIELD,
+            field: missingKeys.join(','),
+          });
+          return undefined;
+        }
 
-      const shouldDeleteSurvey = sixWeekData[deleteField] === 'yes';
-      const isFinalCollection = sixWeekData.Is_Final_Collection === 'yes';
+        const castOk = validateCastable(cleanedData, `${identifier} / week ${weekNum}`, rowNumber, rejected);
+        if (!castOk) return undefined;
+      }
 
       if (shouldDeleteSurvey) {
         skipped.push({
@@ -202,7 +222,7 @@ export const parseSurvey123Csv = async (filename) => {
 
       return {
         ...cleanedData,
-        shouldInsert: !shouldDeleteSurvey && isFinalCollection,
+        shouldInsert,
       };
     }).filter((doc) => !!doc);
   };
@@ -224,7 +244,10 @@ export const parseSurvey123Csv = async (filename) => {
   });
 
   // build bulk operations from valid docs, but additionally surface deleteInsert-level
-  // rejections (e.g. active-days out of range) so the user sees why a survey was dropped
+  // rejections (e.g. active-days out of range) so the user sees why a survey was dropped.
+  // When a survey is rejected for being out-of-range, skip the deleteInsert entirely —
+  // otherwise we would issue a deleteMany with no replacement inserts and silently wipe
+  // existing data for that globalID.
   const bulkOpGroups = docs.map(({ rowNumber, weeks }) => {
     if (!weeks.length) return [];
     const numDaysActive = weeks.reduce((acc, curr) => (
@@ -240,6 +263,7 @@ export const parseSurvey123Csv = async (filename) => {
         field: 'daysActive',
         value: `${numDaysActive} (allowed ${MIN_DAYS_ACTIVE}-${MAX_DAYS_ACTIVE})`,
       });
+      return [];
     }
     return deleteInsert(weeks) || [];
   });

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -207,10 +207,10 @@ export const parseSurvey123Csv = async (filename) => {
     }).filter((doc) => !!doc);
   };
 
-  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => {
-    const unpackedData = unpacker(row, rowNumber);
-    return unpackedData.map(stateToAbbrevTransform);
-  }, { collectErrors: true });
+  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => ({
+    rowNumber,
+    weeks: unpacker(row, rowNumber).map(stateToAbbrevTransform),
+  }), { collectErrors: true });
 
   rejections.forEach(({ rowNumber, error, raw }) => {
     rejected.push({
@@ -225,23 +225,23 @@ export const parseSurvey123Csv = async (filename) => {
 
   // build bulk operations from valid docs, but additionally surface deleteInsert-level
   // rejections (e.g. active-days out of range) so the user sees why a survey was dropped
-  const bulkOpGroups = docs.map((sixWeeksData) => {
-    if (!sixWeeksData.length) return [];
-    const numDaysActive = sixWeeksData.reduce((acc, curr) => (
+  const bulkOpGroups = docs.map(({ rowNumber, weeks }) => {
+    if (!weeks.length) return [];
+    const numDaysActive = weeks.reduce((acc, curr) => (
       acc + (parseInt(curr.daysActive, 10) || 0)
     ), 0);
-    const { shouldInsert } = sixWeeksData.find((d) => !!d) || {};
+    const { shouldInsert } = weeks.find((d) => !!d) || {};
     if (shouldInsert && (numDaysActive < MIN_DAYS_ACTIVE || numDaysActive > MAX_DAYS_ACTIVE)) {
-      const first = sixWeeksData[0] || {};
+      const first = weeks[0] || {};
       rejected.push({
-        rowNumber: 0,
-        identifier: `${first.state || '?'} / ${first.county || '?'} / ${first.year || '?'} / ${first.trap || '?'}`,
+        rowNumber,
+        identifier: `row ${rowNumber} / ${first.state || '?'} / ${first.county || '?'} / ${first.year || '?'} / ${first.trap || '?'}`,
         reason: SURVEY123_REASONS.ACTIVE_DAYS_OUT_OF_RANGE,
         field: 'daysActive',
         value: `${numDaysActive} (allowed ${MIN_DAYS_ACTIVE}-${MAX_DAYS_ACTIVE})`,
       });
     }
-    return deleteInsert(sixWeeksData) || [];
+    return deleteInsert(weeks) || [];
   });
 
   const bulkOp = bulkOpGroups.flat().filter((obj) => !!obj);
@@ -277,6 +277,7 @@ export const uploadCsv = async (filename, options = {}) => {
     return {
       rowCount,
       accepted,
+      willDelete: deleteOp.length,
       skippedRows: skipped.length,
       rejectedRows: rejected.length,
       skipped,
@@ -302,6 +303,7 @@ export const uploadCsv = async (filename, options = {}) => {
   return {
     rowCount,
     accepted,
+    willDelete: deleteOp.length,
     skippedRows: skipped.length,
     rejectedRows: rejected.length,
     skipped,

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -311,8 +311,21 @@ export const uploadCsv = async (filename, options = {}) => {
     };
   }
 
+  // No valid operations to perform — return the parsed diagnostics instead of
+  // throwing so the audit log and /upload/status surface the per-row skip/reject
+  // reasons rather than a bare 'no valid data' error.
   if (!bulkOp.length) {
-    throw newError(RESPONSE_TYPES.BAD_REQUEST, 'no valid data');
+    return {
+      rowCount,
+      accepted: 0,
+      willDelete: 0,
+      skippedRows: skipped.length,
+      rejectedRows: rejected.length,
+      skipped,
+      rejected,
+      deleteRes: { deletedCount: 0 },
+      insertRes: { insertedCount: 0 },
+    };
   }
 
   const deleteRes = deleteOp.length

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -272,14 +272,30 @@ export const parseSurvey123Csv = async (filename) => {
   const insertOp = bulkOp.filter(({ insertOne }) => !!insertOne);
   const deleteOp = bulkOp.filter(({ deleteMany }) => !!deleteMany);
 
+  // De-dup skipped against rejected: when a survey ultimately lands in rejected
+  // (e.g. ACTIVE_DAYS_OUT_OF_RANGE for the whole row), per-week skipped entries
+  // for the same rowNumber would otherwise inflate skippedRows alongside
+  // rejectedRows for the same survey. Show each survey under one bucket.
+  const rejectedRowNumbers = new Set(rejected.map((r) => r.rowNumber));
+  const dedupedSkipped = skipped.filter((s) => !rejectedRowNumbers.has(s.rowNumber));
+
+  // Count surveys (unique rowNumbers) that produced at least one insert op,
+  // not the raw count of insertOne ops (which is per-week — up to 6 per survey).
+  const acceptedRowNumbers = new Set();
+  docs.forEach(({ rowNumber }, idx) => {
+    if (bulkOpGroups[idx]?.some((op) => op.insertOne)) {
+      acceptedRowNumbers.add(rowNumber);
+    }
+  });
+
   return {
     rowCount,
     bulkOp,
     insertOp,
     deleteOp,
-    skipped,
+    skipped: dedupedSkipped,
     rejected,
-    accepted: insertOp.length,
+    accepted: acceptedRowNumbers.size,
   };
 };
 

--- a/src/controllers/survey123.js
+++ b/src/controllers/survey123.js
@@ -10,8 +10,12 @@ import {
   deleteInsert,
   extractObjectFieldsCreator,
   getModelAttributes,
+  MAX_DAYS_ACTIVE,
+  MIN_DAYS_ACTIVE,
   processCSV,
   transformSurvey123GlobalID,
+  tryCastDate,
+  tryCastNumber,
   newError,
 } from '../utils';
 
@@ -40,18 +44,80 @@ const ordinalStrings = Object.entries({
   1: '1st', 2: '2nd', 3: '3rd', 4: '4th', 5: '5th', 6: '6th',
 });
 
+// Skip/reject reason codes — used in audit log + frontend display
+export const SURVEY123_REASONS = {
+  MISSING_REQUIRED_FIELD: 'MISSING_REQUIRED_FIELD',
+  MISSING_FORMAT_FIELD: 'MISSING_FORMAT_FIELD',
+  ROW_PROCESSING_ERROR: 'ROW_PROCESSING_ERROR',
+  MISSING_COLLECTION_DATE: 'MISSING_COLLECTION_DATE',
+  ZERO_DAYS_ACTIVE: 'ZERO_DAYS_ACTIVE',
+  MARKED_DELETE: 'MARKED_DELETE',
+  NOT_FINAL_COLLECTION: 'NOT_FINAL_COLLECTION',
+  ACTIVE_DAYS_OUT_OF_RANGE: 'ACTIVE_DAYS_OUT_OF_RANGE',
+  INVALID_NUMERIC: 'INVALID_NUMERIC',
+  INVALID_DATE: 'INVALID_DATE',
+};
+
+// Fields that mongoose will cast to Number / Date at bulkWrite time —
+// pre-validate them in preview so CastError-class failures are surfaced.
+const NUMERIC_FIELDS = ['spbCount', 'cleridCount', 'daysActive', 'latitude', 'longitude', 'year', 'endobrev', 'FIPS'];
+const DATE_FIELDS = ['collectionDate', 'startDate', 'bloomDate'];
+
+const validateCastable = (cleanedData, identifier, rowNumber, rejected) => {
+  let bad = false;
+  NUMERIC_FIELDS.forEach((field) => {
+    const raw = cleanedData[field];
+    if (raw === undefined || raw === null || raw === '') return;
+    if (!tryCastNumber(raw).ok) {
+      rejected.push({
+        rowNumber,
+        identifier,
+        reason: SURVEY123_REASONS.INVALID_NUMERIC,
+        field,
+        value: String(raw),
+      });
+      bad = true;
+    }
+  });
+  DATE_FIELDS.forEach((field) => {
+    const raw = cleanedData[field];
+    if (raw === undefined || raw === null || raw === '') return;
+    if (!tryCastDate(raw).ok) {
+      rejected.push({
+        rowNumber,
+        identifier,
+        reason: SURVEY123_REASONS.INVALID_DATE,
+        field,
+        value: String(raw),
+      });
+      bad = true;
+    }
+  });
+  return !bad;
+};
+
+const buildIdentifier = (row, rowNumber) => {
+  const state = row.USA_State || row.State || '?';
+  const county = row.County || row['County/Parish'] || '?';
+  const year = row.Year || '?';
+  const trap = row.Trap_name || row['Trap name'] || '?';
+  return `row ${rowNumber} / ${state} / ${county} / ${year} / ${trap}`;
+};
+
 /**
- * @description uploads a csv to the unsummarized collection
+ * @description parses + validates a survey123 CSV without writing to DB.
+ * Returns docs ready for commit, plus structured skipped/rejected lists.
  * @param {String} filename the csv filename on disk
  */
-export const uploadCsv = async (filename) => {
-  const unpacker = (sixWeekData) => {
-    // detect CSV format: new field names use underscores, old ones use spaces/special chars
+export const parseSurvey123Csv = async (filename) => {
+  const skipped = [];
+  const rejected = [];
+
+  const unpacker = (sixWeekData, rowNumber) => {
     const isNewFormat = sixWeekData.USA_State !== undefined;
+    const identifier = buildIdentifier(sixWeekData, rowNumber);
 
     return ordinalStrings.map(([weekNum, weekOrdinal]) => {
-      // convert fields to unsummarized schema
-      // supports both old and new Survey123 CSV export formats
       const convertedRawData = isNewFormat ? {
         bloom: sixWeekData.Species_Bloom,
         bloomDate: sixWeekData.Initial_Bloom,
@@ -96,7 +162,6 @@ export const uploadCsv = async (filename) => {
         year: sixWeekData.Year,
       };
 
-      // will throw error if missing fields
       const cleanedData = extractModelAttributes(convertedRawData);
 
       const deleteField = isNewFormat ? 'DeleteSurvey' : 'Delete this survey?';
@@ -105,33 +170,125 @@ export const uploadCsv = async (filename) => {
         throw newError(RESPONSE_TYPES.BAD_REQUEST, `missing fields: ${missingFields}`);
       }
 
-      if (!cleanedData.collectionDate || !cleanedData.daysActive || cleanedData.daysActive === '0') return undefined; // no data for this week
+      if (!cleanedData.collectionDate) {
+        skipped.push({
+          rowNumber, identifier: `${identifier} / week ${weekNum}`, reason: SURVEY123_REASONS.MISSING_COLLECTION_DATE,
+        });
+        return undefined;
+      }
+      if (!cleanedData.daysActive || cleanedData.daysActive === '0') {
+        skipped.push({
+          rowNumber, identifier: `${identifier} / week ${weekNum}`, reason: SURVEY123_REASONS.ZERO_DAYS_ACTIVE,
+        });
+        return undefined;
+      }
+
+      // numeric/date cast checks — would otherwise throw at bulkWrite time
+      const castOk = validateCastable(cleanedData, `${identifier} / week ${weekNum}`, rowNumber, rejected);
+      if (!castOk) return undefined;
 
       const shouldDeleteSurvey = sixWeekData[deleteField] === 'yes';
       const isFinalCollection = sixWeekData.Is_Final_Collection === 'yes';
 
+      if (shouldDeleteSurvey) {
+        skipped.push({
+          rowNumber, identifier: `${identifier} / week ${weekNum}`, reason: SURVEY123_REASONS.MARKED_DELETE,
+        });
+      } else if (!isFinalCollection) {
+        skipped.push({
+          rowNumber, identifier: `${identifier} / week ${weekNum}`, reason: SURVEY123_REASONS.NOT_FINAL_COLLECTION,
+        });
+      }
+
       return {
         ...cleanedData,
-        shouldInsert: !shouldDeleteSurvey && isFinalCollection, // only insert if data is good and final
+        shouldInsert: !shouldDeleteSurvey && isFinalCollection,
       };
-    }).filter((doc) => !!doc); // remove all nulls
+    }).filter((doc) => !!doc);
   };
 
-  const { docs, rowCount } = await processCSV(filename, (row) => {
-    // attempt to unpack all weeks 1-6 and push all
-    const unpackedData = unpacker(row);
+  const { docs, rowCount, rejections } = await processCSV(filename, (row, rowNumber) => {
+    const unpackedData = unpacker(row, rowNumber);
     return unpackedData.map(stateToAbbrevTransform);
+  }, { collectErrors: true });
+
+  rejections.forEach(({ rowNumber, error, raw }) => {
+    rejected.push({
+      rowNumber,
+      identifier: buildIdentifier(raw, rowNumber),
+      reason: error?.message?.startsWith('missing fields')
+        ? SURVEY123_REASONS.MISSING_REQUIRED_FIELD
+        : SURVEY123_REASONS.ROW_PROCESSING_ERROR,
+      field: error?.message || '',
+    });
   });
 
-  // spread out the operation into sequential deletes and inserts
-  const bulkOp = docs.flatMap(deleteInsert).filter((obj) => !!obj);
+  // build bulk operations from valid docs, but additionally surface deleteInsert-level
+  // rejections (e.g. active-days out of range) so the user sees why a survey was dropped
+  const bulkOpGroups = docs.map((sixWeeksData) => {
+    if (!sixWeeksData.length) return [];
+    const numDaysActive = sixWeeksData.reduce((acc, curr) => (
+      acc + (parseInt(curr.daysActive, 10) || 0)
+    ), 0);
+    const { shouldInsert } = sixWeeksData.find((d) => !!d) || {};
+    if (shouldInsert && (numDaysActive < MIN_DAYS_ACTIVE || numDaysActive > MAX_DAYS_ACTIVE)) {
+      const first = sixWeeksData[0] || {};
+      rejected.push({
+        rowNumber: 0,
+        identifier: `${first.state || '?'} / ${first.county || '?'} / ${first.year || '?'} / ${first.trap || '?'}`,
+        reason: SURVEY123_REASONS.ACTIVE_DAYS_OUT_OF_RANGE,
+        field: 'daysActive',
+        value: `${numDaysActive} (allowed ${MIN_DAYS_ACTIVE}-${MAX_DAYS_ACTIVE})`,
+      });
+    }
+    return deleteInsert(sixWeeksData) || [];
+  });
+
+  const bulkOp = bulkOpGroups.flat().filter((obj) => !!obj);
+  const insertOp = bulkOp.filter(({ insertOne }) => !!insertOne);
+  const deleteOp = bulkOp.filter(({ deleteMany }) => !!deleteMany);
+
+  return {
+    rowCount,
+    bulkOp,
+    insertOp,
+    deleteOp,
+    skipped,
+    rejected,
+    accepted: insertOp.length,
+  };
+};
+
+/**
+ * @description uploads a csv to the unsummarized collection
+ * @param {String} filename the csv filename on disk
+ * @param {Object} [options]
+ * @param {Boolean} [options.dryRun=false] when true, parse + validate only; do not write to DB
+ */
+export const uploadCsv = async (filename, options = {}) => {
+  const { dryRun = false } = options;
+
+  const parsed = await parseSurvey123Csv(filename);
+  const {
+    rowCount, bulkOp, insertOp, deleteOp, skipped, rejected, accepted,
+  } = parsed;
+
+  if (dryRun) {
+    return {
+      rowCount,
+      accepted,
+      skippedRows: skipped.length,
+      rejectedRows: rejected.length,
+      skipped,
+      rejected,
+      deleteRes: { deletedCount: 0 },
+      insertRes: { insertedCount: 0 },
+    };
+  }
 
   if (!bulkOp.length) {
     throw newError(RESPONSE_TYPES.BAD_REQUEST, 'no valid data');
   }
-
-  const insertOp = bulkOp.filter(({ insertOne }) => !!insertOne);
-  const deleteOp = bulkOp.filter(({ deleteMany }) => !!deleteMany);
 
   const deleteRes = deleteOp.length
     ? await UnsummarizedTrappingModel.bulkWrite(deleteOp, { ordered: false })
@@ -140,12 +297,18 @@ export const uploadCsv = async (filename) => {
     ? await UnsummarizedTrappingModel.bulkWrite(insertOp, { ordered: false })
     : { insertedCount: 0 };
 
-  // run entire pipeline
-  // don't throw the error here since we want to return 200 immediately
-  // also don't await it for the same purpose; run pipeline in background
   runPipelineAll().catch(console.error);
 
-  return { rowCount, deleteRes, insertRes };
+  return {
+    rowCount,
+    accepted,
+    skippedRows: skipped.length,
+    rejectedRows: rejected.length,
+    skipped,
+    rejected,
+    deleteRes,
+    insertRes,
+  };
 };
 
 /**

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,9 +1,11 @@
 import SummarizedCountyModel from './summarized-county';
 import SummarizedRangerDistrictModel from './summarized-rangerdistrict';
 import UnsummarizedTrappingModel from './unsummarized-trapping';
+import UploadAuditModel from './upload-audit';
 
 export {
   SummarizedCountyModel,
   SummarizedRangerDistrictModel,
   UnsummarizedTrappingModel,
+  UploadAuditModel,
 };

--- a/src/models/upload-audit.js
+++ b/src/models/upload-audit.js
@@ -1,0 +1,38 @@
+/* eslint-disable sort-keys */
+import mongoose, { Schema } from 'mongoose';
+
+// per-row rejection/skip entry — no rawRow stored, only safe identifiers + reason
+const RowOutcomeSchema = new Schema({
+  rowNumber: { type: Number },
+  identifier: { type: String }, // e.g. "GA / Bibb / 2024 / Flat Creek PFA"
+  reason: { type: String }, // enum code, e.g. INVALID_NUMERIC
+  field: { type: String }, // optional: which field caused the issue
+  value: { type: String }, // optional: raw value as string
+}, { _id: false });
+
+const UploadAuditSchema = new Schema({
+  uploadId: { type: String, index: true, unique: true },
+  uploadedAt: { type: Date, default: Date.now, index: true },
+  uploadedBy: { type: String }, // user email or "survey123-webhook"
+  source: { type: String }, // "survey123" | "summarized-county" | "summarized-county-spots" | "summarized-rangerdistrict" | "summarized-rangerdistrict-spots"
+  filename: { type: String },
+
+  totalRows: { type: Number, default: 0 },
+  acceptedRows: { type: Number, default: 0 },
+  skippedRows: { type: Number, default: 0 },
+  rejectedRows: { type: Number, default: 0 },
+
+  skipped: { type: [RowOutcomeSchema], default: [] },
+  rejected: { type: [RowOutcomeSchema], default: [] },
+
+  bulkWriteResult: { type: Object, default: null },
+
+  status: { type: String }, // "success" | "partial" | "failed"
+  errorMessage: { type: String, default: null },
+});
+
+UploadAuditSchema.index({ uploadedAt: -1 });
+
+const UploadAuditModel = mongoose.model('UploadAudit', UploadAuditSchema);
+
+export default UploadAuditModel;

--- a/src/models/upload-audit.js
+++ b/src/models/upload-audit.js
@@ -25,9 +25,17 @@ const UploadAuditSchema = new Schema({
   skipped: { type: [RowOutcomeSchema], default: [] },
   rejected: { type: [RowOutcomeSchema], default: [] },
 
+  // flags whether the persisted skipped/rejected arrays were truncated to fit
+  // MAX_AUDIT_ENTRIES_PER_LIST — surface to the UI so users know the lists are
+  // incomplete when rejectedRows/skippedRows exceed the visible entries.
+  truncated: {
+    skipped: { type: Boolean, default: false },
+    rejected: { type: Boolean, default: false },
+  },
+
   bulkWriteResult: { type: Object, default: null },
 
-  status: { type: String }, // "success" | "partial" | "failed"
+  status: { type: String }, // "processing" | "success" | "partial" | "failed"
   errorMessage: { type: String, default: null },
 });
 

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -5,6 +5,7 @@ import summarizedCountyRouter from './summarized-county';
 import summarizedRangerDistrictRouter from './summarized-rangerdistrict';
 import survey123Router from './survey123';
 import unsummarizedTrappingRouter from './unsummarized-trapping';
+import uploadAuditRouter from './upload-audit';
 
 export default {
   healthcheck,
@@ -14,4 +15,5 @@ export default {
   'summarized-rangerdistrict': summarizedRangerDistrictRouter,
   survey123: survey123Router,
   'unsummarized-trapping': unsummarizedTrappingRouter,
+  'upload-audit': uploadAuditRouter,
 };

--- a/src/routers/summarized-county.js
+++ b/src/routers/summarized-county.js
@@ -1,10 +1,13 @@
+import crypto from 'crypto';
 import { Router } from 'express';
 import multer from 'multer';
 
 import {
   deleteFile,
+  deriveUploadStatus,
   generateErrorResponse,
   generateResponse,
+  persistUploadAudit,
 } from '../utils';
 
 import { RESPONSE_TYPES } from '../constants';
@@ -91,6 +94,25 @@ summarizedCountyRouter.route('/filter')
     }
   });
 
+summarizedCountyRouter.route('/spots/upload/preview')
+  .post(requireAuth, upload.single('csv'), async (req, res) => {
+    if (!req.file) {
+      res.send(generateResponse(RESPONSE_TYPES.NO_CONTENT, 'missing file'));
+      return;
+    }
+    try {
+      const result = await SummarizedCounty.uploadSpotsCsv(req.file.path, { dryRun: true });
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, result));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      res.status(status).send(errorResponse);
+    } finally {
+      setTimeout(() => deleteFile(req.file.path), 1000 * 10);
+    }
+  });
+
 summarizedCountyRouter.route('/spots/upload')
   .post(requireAuth, upload.single('csv'), async (req, res) => {
     if (!req.file) {
@@ -98,23 +120,62 @@ summarizedCountyRouter.route('/spots/upload')
       return;
     }
 
+    const uploadId = crypto.randomUUID();
+    const originalFilename = req.file.originalname;
+
     try {
       const uploadResult = await SummarizedCounty.uploadSpotsCsv(req.file.path);
       Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-county-spots',
+        filename: originalFilename,
+        uploadResult,
+        status: deriveUploadStatus(uploadResult),
+      });
+
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
         message: 'file uploaded successfully',
+        uploadId,
       }));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-county-spots',
+        filename: originalFilename,
+        uploadResult: null,
+        status: 'failed',
+        errorMessage: errorResponse.error || 'Upload failed',
+      });
+      res.status(status).send(errorResponse);
+    } finally {
+      setTimeout(() => {
+        deleteFile(req.file.path);
+      }, 1000 * 10);
+    }
+  });
+
+summarizedCountyRouter.route('/upload/preview')
+  .post(requireAuth, upload.single('csv'), async (req, res) => {
+    if (!req.file) {
+      res.send(generateResponse(RESPONSE_TYPES.NO_CONTENT, 'missing file'));
+      return;
+    }
+    try {
+      const result = await SummarizedCounty.uploadCsv(req.file.path, { dryRun: true });
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, result));
     } catch (error) {
       const errorResponse = generateErrorResponse(error);
       const { error: errorMessage, status } = errorResponse;
       console.log(errorMessage);
       res.status(status).send(errorResponse);
     } finally {
-      setTimeout(() => {
-        deleteFile(req.file.path);
-      }, 1000 * 10);
+      setTimeout(() => deleteFile(req.file.path), 1000 * 10);
     }
   });
 
@@ -125,18 +186,38 @@ summarizedCountyRouter.route('/upload')
       return;
     }
 
+    const uploadId = crypto.randomUUID();
+    const originalFilename = req.file.originalname;
+
     try {
       const uploadResult = await SummarizedCounty.uploadCsv(req.file.path);
       Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-county',
+        filename: originalFilename,
+        uploadResult,
+        status: deriveUploadStatus(uploadResult),
+      });
+
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
         message: 'file uploaded successfully',
+        uploadId,
       }));
     } catch (error) {
       const errorResponse = generateErrorResponse(error);
       const { error: errorMessage, status } = errorResponse;
       console.log(errorMessage);
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-county',
+        filename: originalFilename,
+        uploadResult: null,
+        status: 'failed',
+        errorMessage: errorResponse.error || 'Upload failed',
+      });
       res.status(status).send(errorResponse);
     } finally {
       setTimeout(() => {

--- a/src/routers/summarized-rangerdistrict.js
+++ b/src/routers/summarized-rangerdistrict.js
@@ -1,10 +1,13 @@
+import crypto from 'crypto';
 import { Router } from 'express';
 import multer from 'multer';
 
 import {
   deleteFile,
+  deriveUploadStatus,
   generateErrorResponse,
   generateResponse,
+  persistUploadAudit,
 } from '../utils';
 
 import { RESPONSE_TYPES } from '../constants';
@@ -91,6 +94,25 @@ summarizedRangerDistrictRouter.route('/filter')
     }
   });
 
+summarizedRangerDistrictRouter.route('/spots/upload/preview')
+  .post(requireAuth, upload.single('csv'), async (req, res) => {
+    if (!req.file) {
+      res.send(generateResponse(RESPONSE_TYPES.NO_CONTENT, 'missing file'));
+      return;
+    }
+    try {
+      const result = await SummarizedRangerDistrict.uploadSpotsCsv(req.file.path, { dryRun: true });
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, result));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      res.status(status).send(errorResponse);
+    } finally {
+      setTimeout(() => deleteFile(req.file.path), 1000 * 10);
+    }
+  });
+
 summarizedRangerDistrictRouter.route('/spots/upload')
   .post(requireAuth, upload.single('csv'), async (req, res) => {
     if (!req.file) {
@@ -98,24 +120,63 @@ summarizedRangerDistrictRouter.route('/spots/upload')
       return;
     }
 
+    const uploadId = crypto.randomUUID();
+    const originalFilename = req.file.originalname;
+
     try {
       const uploadResult = await SummarizedRangerDistrict.uploadSpotsCsv(req.file.path);
       Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-rangerdistrict-spots',
+        filename: originalFilename,
+        uploadResult,
+        status: deriveUploadStatus(uploadResult),
+      });
+
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
         message: 'file uploaded successfully',
+        uploadId,
       }));
     } catch (error) {
       const errorResponse = generateErrorResponse(error);
       const { error: errorMessage, status } = errorResponse;
       console.log(errorMessage);
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-rangerdistrict-spots',
+        filename: originalFilename,
+        uploadResult: null,
+        status: 'failed',
+        errorMessage: errorResponse.error || 'Upload failed',
+      });
       res.status(status).send(errorResponse);
     } finally {
       // wrapping in a setTimeout to invoke the event loop, so fs knows the file exists
       setTimeout(() => {
         deleteFile(req.file.path);
       }, 1000 * 10);
+    }
+  });
+
+summarizedRangerDistrictRouter.route('/upload/preview')
+  .post(requireAuth, upload.single('csv'), async (req, res) => {
+    if (!req.file) {
+      res.send(generateResponse(RESPONSE_TYPES.NO_CONTENT, 'missing file'));
+      return;
+    }
+    try {
+      const result = await SummarizedRangerDistrict.uploadCsv(req.file.path, { dryRun: true });
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, result));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      res.status(status).send(errorResponse);
+    } finally {
+      setTimeout(() => deleteFile(req.file.path), 1000 * 10);
     }
   });
 
@@ -126,18 +187,38 @@ summarizedRangerDistrictRouter.route('/upload')
       return;
     }
 
+    const uploadId = crypto.randomUUID();
+    const originalFilename = req.file.originalname;
+
     try {
       const uploadResult = await SummarizedRangerDistrict.uploadCsv(req.file.path);
       Pipeline.runPipelineAll().catch((err) => console.error('Pipeline failed after upload:', err));
 
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-rangerdistrict',
+        filename: originalFilename,
+        uploadResult,
+        status: deriveUploadStatus(uploadResult),
+      });
+
       res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data: uploadResult,
         message: 'file uploaded successfully',
+        uploadId,
       }));
     } catch (error) {
       const errorResponse = generateErrorResponse(error);
       const { error: errorMessage, status } = errorResponse;
       console.log(errorMessage);
+      await persistUploadAudit({
+        uploadId,
+        source: 'summarized-rangerdistrict',
+        filename: originalFilename,
+        uploadResult: null,
+        status: 'failed',
+        errorMessage: errorResponse.error || 'Upload failed',
+      });
       res.status(status).send(errorResponse);
     } finally {
       // wrapping in a setTimeout to invoke the event loop, so fs knows the file exists

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -4,8 +4,10 @@ import multer from 'multer';
 
 import {
   deleteFile,
+  deriveUploadStatus,
   generateErrorResponse,
   generateResponse,
+  persistUploadAudit,
 } from '../utils';
 
 import { requireAuth } from '../middleware';
@@ -27,6 +29,26 @@ const cleanupStatus = (uploadId) => {
   setTimeout(() => uploadStatuses.delete(uploadId), STATUS_TTL_MS);
 };
 
+survey123Router.route('/upload/preview')
+  .post(requireAuth, upload.single('csv'), async (req, res) => {
+    if (!req.file) {
+      res.send(generateResponse(RESPONSE_TYPES.NO_CONTENT, 'missing file'));
+      return;
+    }
+    const filePath = req.file.path;
+    try {
+      const result = await Survey123.uploadCsv(filePath, { dryRun: true });
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, result));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      res.status(status).send(errorResponse);
+    } finally {
+      setTimeout(() => deleteFile(filePath), 1000 * 10);
+    }
+  });
+
 survey123Router.route('/upload')
   .post(requireAuth, upload.single('csv'), async (req, res) => {
     if (!req.file) {
@@ -35,6 +57,7 @@ survey123Router.route('/upload')
     }
 
     const filePath = req.file.path;
+    const originalFilename = req.file.originalname;
     const uploadId = crypto.randomUUID();
 
     uploadStatuses.set(uploadId, { status: 'processing' });
@@ -45,20 +68,37 @@ survey123Router.route('/upload')
     // Process CSV in background
     console.log(`[survey123] starting background upload for ${uploadId}`);
     Survey123.uploadCsv(filePath)
-      .then((result) => {
+      .then(async (result) => {
         console.log(`[survey123] upload ${uploadId} completed successfully`);
+        const auditStatus = deriveUploadStatus(result);
         uploadStatuses.set(uploadId, {
-          status: 'success',
-          message: `CSV imported successfully. ${result.rowCount} rows processed, ${result.insertRes?.insertedCount ?? 0} inserted, ${result.deleteRes?.deletedCount ?? 0} deleted. Pipeline has been started.`,
+          status: auditStatus === 'failed' ? 'error' : 'success',
+          message: `CSV imported. ${result.rowCount} rows parsed, ${result.accepted} accepted, ${result.skipped.length} skipped, ${result.rejected.length} rejected. Pipeline started.`,
+          result,
+        });
+        await persistUploadAudit({
+          uploadId,
+          source: 'survey123',
+          filename: originalFilename,
+          uploadResult: result,
+          status: auditStatus,
         });
         cleanupStatus(uploadId);
       })
-      .catch((err) => {
+      .catch(async (err) => {
         console.error(`[survey123] upload ${uploadId} FAILED:`, err);
         const errorResponse = generateErrorResponse(err);
         uploadStatuses.set(uploadId, {
           status: 'error',
           message: errorResponse.error || 'Upload failed',
+        });
+        await persistUploadAudit({
+          uploadId,
+          source: 'survey123',
+          filename: originalFilename,
+          uploadResult: null,
+          status: 'failed',
+          errorMessage: errorResponse.error || 'Upload failed',
         });
         cleanupStatus(uploadId);
       })

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -21,13 +21,12 @@ const upload = multer({ dest: './uploads' });
 
 const survey123Router = Router();
 
-// In-memory store for async upload statuses
-const uploadStatuses = new Map();
-
-// Clean up completed statuses after 30 minutes
-const STATUS_TTL_MS = 30 * 60 * 1000;
-const cleanupStatus = (uploadId) => {
-  setTimeout(() => uploadStatuses.delete(uploadId), STATUS_TTL_MS);
+// Map the persisted audit.status to the client-facing /upload/status response.
+// 'partial' is preserved distinct from 'success' so the UI can surface that
+// some rows were rejected even though the upload completed.
+const auditStatusToClientStatus = (auditStatus) => {
+  if (auditStatus === 'failed') return 'error';
+  return auditStatus; // 'processing' | 'success' | 'partial'
 };
 
 survey123Router.route('/upload/preview')
@@ -61,7 +60,15 @@ survey123Router.route('/upload')
     const originalFilename = req.file.originalname;
     const uploadId = crypto.randomUUID();
 
-    uploadStatuses.set(uploadId, { status: 'processing' });
+    // Persist a 'processing' audit row BEFORE returning 202. The DB is the only
+    // source of truth — if the dyno restarts mid-processing, /upload/status can
+    // still return 'processing' instead of 404. No in-memory state.
+    await persistUploadAudit({
+      uploadId,
+      source: 'survey123',
+      filename: originalFilename,
+      status: 'processing',
+    });
 
     // Return 202 immediately to avoid Heroku 30s H12 timeout
     res.status(202).send(generateResponse(RESPONSE_TYPES.SUCCESS, { uploadId }));
@@ -71,28 +78,17 @@ survey123Router.route('/upload')
     Survey123.uploadCsv(filePath)
       .then(async (result) => {
         console.log(`[survey123] upload ${uploadId} completed successfully`);
-        const auditStatus = deriveUploadStatus(result);
-        uploadStatuses.set(uploadId, {
-          status: auditStatus === 'failed' ? 'error' : 'success',
-          message: `CSV imported. ${result.rowCount} rows parsed, ${result.accepted} accepted, ${result.skipped.length} skipped, ${result.rejected.length} rejected. Pipeline started.`,
-          result,
-        });
         await persistUploadAudit({
           uploadId,
           source: 'survey123',
           filename: originalFilename,
           uploadResult: result,
-          status: auditStatus,
+          status: deriveUploadStatus(result),
         });
-        cleanupStatus(uploadId);
       })
       .catch(async (err) => {
         console.error(`[survey123] upload ${uploadId} FAILED:`, err);
         const errorResponse = generateErrorResponse(err);
-        uploadStatuses.set(uploadId, {
-          status: 'error',
-          message: errorResponse.error || 'Upload failed',
-        });
         await persistUploadAudit({
           uploadId,
           source: 'survey123',
@@ -101,7 +97,6 @@ survey123Router.route('/upload')
           status: 'failed',
           errorMessage: errorResponse.error || 'Upload failed',
         });
-        cleanupStatus(uploadId);
       })
       .finally(() => {
         setTimeout(() => deleteFile(filePath), 1000 * 10);
@@ -120,36 +115,37 @@ survey123Router.route('/upload/status')
       return;
     }
 
-    // In-memory status is the source of truth for in-flight uploads. If it's
-    // missing (e.g. the dyno restarted after processing finished), fall back to
-    // the persisted audit row so the client can still resolve the final state.
-    let statusData = uploadStatuses.get(uploadId);
-
-    if (!statusData) {
-      const audit = await UploadAuditModel.findOne({ uploadId }).lean();
-      if (audit) {
-        statusData = {
-          status: audit.status === 'failed' ? 'error' : 'success',
-          message: audit.errorMessage || 'CSV import completed.',
-          result: {
-            rowCount: audit.totalRows,
-            accepted: audit.acceptedRows,
-            skipped: audit.skipped || [],
-            rejected: audit.rejected || [],
-          },
-        };
-      }
-    }
-
-    if (!statusData) {
-      res.status(404).send(generateErrorResponse({
-        type: RESPONSE_TYPES.NOT_FOUND,
-        message: 'Upload not found or expired',
+    let audit;
+    try {
+      audit = await UploadAuditModel.findOne({ uploadId }).lean();
+    } catch (err) {
+      console.error('[survey123] /upload/status DB error:', err);
+      res.status(500).send(generateErrorResponse({
+        type: RESPONSE_TYPES.INTERNAL_ERROR,
+        message: 'Failed to look up upload status',
       }));
       return;
     }
 
-    res.send(generateResponse(RESPONSE_TYPES.SUCCESS, statusData));
+    if (!audit) {
+      res.status(404).send(generateErrorResponse({
+        type: RESPONSE_TYPES.NOT_FOUND,
+        message: 'Upload not found',
+      }));
+      return;
+    }
+
+    res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
+      status: auditStatusToClientStatus(audit.status),
+      message: audit.errorMessage || `CSV import ${audit.status}.`,
+      result: {
+        rowCount: audit.totalRows,
+        accepted: audit.acceptedRows,
+        skipped: audit.skipped || [],
+        rejected: audit.rejected || [],
+        truncated: audit.truncated || { skipped: false, rejected: false },
+      },
+    }));
   });
 
 survey123Router.route('/webhook')

--- a/src/routers/survey123.js
+++ b/src/routers/survey123.js
@@ -15,6 +15,7 @@ import { requireAuth } from '../middleware';
 import { RESPONSE_TYPES } from '../constants';
 
 import { Survey123 } from '../controllers';
+import { UploadAuditModel } from '../models';
 
 const upload = multer({ dest: './uploads' });
 
@@ -108,8 +109,8 @@ survey123Router.route('/upload')
   });
 
 survey123Router.route('/upload/status')
-  .get(requireAuth, (req, res) => {
-    const { uploadId } = req.query;
+  .get(requireAuth, async (req, res) => {
+    const uploadId = String(req.query.uploadId || '');
 
     if (!uploadId) {
       res.status(400).send(generateErrorResponse({
@@ -119,7 +120,26 @@ survey123Router.route('/upload/status')
       return;
     }
 
-    const statusData = uploadStatuses.get(uploadId);
+    // In-memory status is the source of truth for in-flight uploads. If it's
+    // missing (e.g. the dyno restarted after processing finished), fall back to
+    // the persisted audit row so the client can still resolve the final state.
+    let statusData = uploadStatuses.get(uploadId);
+
+    if (!statusData) {
+      const audit = await UploadAuditModel.findOne({ uploadId }).lean();
+      if (audit) {
+        statusData = {
+          status: audit.status === 'failed' ? 'error' : 'success',
+          message: audit.errorMessage || 'CSV import completed.',
+          result: {
+            rowCount: audit.totalRows,
+            accepted: audit.acceptedRows,
+            skipped: audit.skipped || [],
+            rejected: audit.rejected || [],
+          },
+        };
+      }
+    }
 
     if (!statusData) {
       res.status(404).send(generateErrorResponse({

--- a/src/routers/upload-audit.js
+++ b/src/routers/upload-audit.js
@@ -1,0 +1,64 @@
+import { Router } from 'express';
+
+import { UploadAuditModel } from '../models';
+import { requireAuth } from '../middleware';
+import { RESPONSE_TYPES } from '../constants';
+import { generateErrorResponse, generateResponse } from '../utils';
+
+const uploadAuditRouter = Router();
+
+// list — paginated, latest first; optional ?status=partial|failed|success and ?source=...
+uploadAuditRouter.route('/')
+  .get(requireAuth, async (req, res) => {
+    try {
+      const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+      const limit = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
+      const skip = (page - 1) * limit;
+
+      const filter = {};
+      if (req.query.status) filter.status = req.query.status;
+      if (req.query.source) filter.source = req.query.source;
+
+      const [data, total] = await Promise.all([
+        UploadAuditModel.find(filter)
+          .sort({ uploadedAt: -1 })
+          .skip(skip)
+          .limit(limit)
+          .select('-skipped -rejected') // exclude heavy arrays from list view
+          .lean()
+          .exec(),
+        UploadAuditModel.countDocuments(filter),
+      ]);
+
+      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
+        data,
+        pagination: {
+          page, limit, total, totalPages: Math.ceil(total / limit),
+        },
+      }));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      res.status(status).send(errorResponse);
+    }
+  });
+
+// detail — full doc including skipped + rejected arrays
+uploadAuditRouter.route('/:uploadId')
+  .get(requireAuth, async (req, res) => {
+    try {
+      const doc = await UploadAuditModel.findOne({ uploadId: req.params.uploadId }).lean();
+      if (!doc) {
+        return res.status(404).send(generateResponse(RESPONSE_TYPES.NOT_FOUND, 'audit entry not found'));
+      }
+      return res.send(generateResponse(RESPONSE_TYPES.SUCCESS, doc));
+    } catch (error) {
+      const errorResponse = generateErrorResponse(error);
+      const { error: errorMessage, status } = errorResponse;
+      console.log(errorMessage);
+      return res.status(status).send(errorResponse);
+    }
+  });
+
+export default uploadAuditRouter;

--- a/src/routers/upload-audit.js
+++ b/src/routers/upload-audit.js
@@ -15,9 +15,12 @@ uploadAuditRouter.route('/')
       const limit = Math.min(200, Math.max(1, parseInt(req.query.limit, 10) || 50));
       const skip = (page - 1) * limit;
 
+      // Coerce query params to strings + allowlist status to avoid Mongo
+      // operator injection (e.g. ?status[$ne]=...).
+      const ALLOWED_STATUS = ['success', 'partial', 'failed'];
       const filter = {};
-      if (req.query.status) filter.status = req.query.status;
-      if (req.query.source) filter.source = req.query.source;
+      if (ALLOWED_STATUS.includes(req.query.status)) filter.status = req.query.status;
+      if (req.query.source) filter.source = String(req.query.source);
 
       const [data, total] = await Promise.all([
         UploadAuditModel.find(filter)

--- a/src/routers/upload-audit.js
+++ b/src/routers/upload-audit.js
@@ -16,11 +16,29 @@ uploadAuditRouter.route('/')
       const skip = (page - 1) * limit;
 
       // Coerce query params to strings + allowlist status to avoid Mongo
-      // operator injection (e.g. ?status[$ne]=...).
-      const ALLOWED_STATUS = ['success', 'partial', 'failed'];
+      // operator injection (e.g. ?status[$ne]=...). Reject array-valued or
+      // unknown filters with 400 — silently dropping them would return the
+      // full unfiltered set, which the caller did not ask for.
+      const ALLOWED_STATUS = ['processing', 'success', 'partial', 'failed'];
       const filter = {};
-      if (ALLOWED_STATUS.includes(req.query.status)) filter.status = req.query.status;
-      if (req.query.source) filter.source = String(req.query.source);
+      if (req.query.status !== undefined) {
+        if (typeof req.query.status !== 'string' || !ALLOWED_STATUS.includes(req.query.status)) {
+          return res.status(400).send(generateErrorResponse({
+            type: RESPONSE_TYPES.BAD_REQUEST,
+            message: `Invalid status filter. Allowed: ${ALLOWED_STATUS.join(', ')}`,
+          }));
+        }
+        filter.status = req.query.status;
+      }
+      if (req.query.source !== undefined) {
+        if (typeof req.query.source !== 'string') {
+          return res.status(400).send(generateErrorResponse({
+            type: RESPONSE_TYPES.BAD_REQUEST,
+            message: 'Invalid source filter',
+          }));
+        }
+        filter.source = req.query.source;
+      }
 
       const [data, total] = await Promise.all([
         UploadAuditModel.find(filter)
@@ -33,7 +51,7 @@ uploadAuditRouter.route('/')
         UploadAuditModel.countDocuments(filter),
       ]);
 
-      res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
+      return res.send(generateResponse(RESPONSE_TYPES.SUCCESS, {
         data,
         pagination: {
           page, limit, total, totalPages: Math.ceil(total / limit),
@@ -43,7 +61,7 @@ uploadAuditRouter.route('/')
       const errorResponse = generateErrorResponse(error);
       const { error: errorMessage, status } = errorResponse;
       console.log(errorMessage);
-      res.status(status).send(errorResponse);
+      return res.status(status).send(errorResponse);
     }
   });
 

--- a/src/utils/audit.js
+++ b/src/utils/audit.js
@@ -5,8 +5,20 @@ import { UploadAuditModel } from '../models';
 const MAX_AUDIT_ENTRIES_PER_LIST = 1000;
 
 /**
- * @description persists a single upload audit doc. Truncates very long
- * skipped/rejected arrays to keep document size sane.
+ * @description upserts an upload audit doc by uploadId. Safe to call multiple
+ * times for the same uploadId — first call (status='processing') creates the
+ * row before the work starts, subsequent calls update it with the final result.
+ * This means async uploads always have a persisted audit row, even if the
+ * dyno restarts mid-processing.
+ *
+ * Truncates very long skipped/rejected arrays to keep document size sane and
+ * sets `truncated.{skipped,rejected}` so the UI can flag incomplete lists.
+ *
+ * TODO(#14 follow-up): uploadedBy currently defaults to 'admin' because
+ * requireAuth middleware does not attach req.user. Backend /v3/user/auth must
+ * return user info and the middleware must propagate it onto req before this
+ * field is meaningful. Tracked separately so the data-corruption fixes in this
+ * PR can ship without a cross-repo change.
  */
 export const persistUploadAudit = async ({
   uploadId,
@@ -17,31 +29,46 @@ export const persistUploadAudit = async ({
   status,
   errorMessage,
 }) => {
-  const truncate = (arr) => (
-    Array.isArray(arr) && arr.length > MAX_AUDIT_ENTRIES_PER_LIST
-      ? arr.slice(0, MAX_AUDIT_ENTRIES_PER_LIST)
-      : (arr || [])
-  );
+  const skippedArr = Array.isArray(uploadResult?.skipped) ? uploadResult.skipped : [];
+  const rejectedArr = Array.isArray(uploadResult?.rejected) ? uploadResult.rejected : [];
+  const truncate = (arr) => (arr.length > MAX_AUDIT_ENTRIES_PER_LIST
+    ? arr.slice(0, MAX_AUDIT_ENTRIES_PER_LIST)
+    : arr);
+
+  // Only set row-data fields when we actually have a result. At upload start
+  // (status='processing'), uploadResult is undefined and we want the schema
+  // defaults to apply rather than overwriting any existing row with zeros.
+  const update = {
+    source,
+    uploadedBy: uploadedBy || 'admin',
+    filename: filename || null,
+    status,
+    errorMessage: errorMessage || null,
+  };
+
+  if (uploadResult) {
+    update.totalRows = uploadResult.rowCount ?? 0;
+    update.acceptedRows = uploadResult.accepted ?? 0;
+    update.skippedRows = skippedArr.length;
+    update.rejectedRows = rejectedArr.length;
+    update.skipped = truncate(skippedArr);
+    update.rejected = truncate(rejectedArr);
+    update.truncated = {
+      skipped: skippedArr.length > MAX_AUDIT_ENTRIES_PER_LIST,
+      rejected: rejectedArr.length > MAX_AUDIT_ENTRIES_PER_LIST,
+    };
+    update.bulkWriteResult = uploadResult.bulkWriteResult
+      || (uploadResult.insertRes || uploadResult.deleteRes
+        ? { insertRes: uploadResult.insertRes, deleteRes: uploadResult.deleteRes }
+        : null);
+  }
 
   try {
-    await UploadAuditModel.create({
-      uploadId: uploadId || crypto.randomUUID(),
-      source,
-      uploadedBy: uploadedBy || 'admin',
-      filename: filename || null,
-      totalRows: uploadResult?.rowCount ?? 0,
-      acceptedRows: uploadResult?.accepted ?? 0,
-      skippedRows: uploadResult?.skipped?.length ?? 0,
-      rejectedRows: uploadResult?.rejected?.length ?? 0,
-      skipped: truncate(uploadResult?.skipped),
-      rejected: truncate(uploadResult?.rejected),
-      bulkWriteResult: uploadResult?.bulkWriteResult
-        || (uploadResult?.insertRes || uploadResult?.deleteRes
-          ? { insertRes: uploadResult.insertRes, deleteRes: uploadResult.deleteRes }
-          : null),
-      status,
-      errorMessage: errorMessage || null,
-    });
+    await UploadAuditModel.findOneAndUpdate(
+      { uploadId: uploadId || crypto.randomUUID() },
+      update,
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
   } catch (err) {
     // audit logging must never break the actual upload
     console.error('[upload-audit] failed to persist audit doc:', err);

--- a/src/utils/audit.js
+++ b/src/utils/audit.js
@@ -1,0 +1,60 @@
+import crypto from 'crypto';
+
+import { UploadAuditModel } from '../models';
+
+const MAX_AUDIT_ENTRIES_PER_LIST = 1000;
+
+/**
+ * @description persists a single upload audit doc. Truncates very long
+ * skipped/rejected arrays to keep document size sane.
+ */
+export const persistUploadAudit = async ({
+  uploadId,
+  source,
+  uploadedBy,
+  filename,
+  uploadResult,
+  status,
+  errorMessage,
+}) => {
+  const truncate = (arr) => (
+    Array.isArray(arr) && arr.length > MAX_AUDIT_ENTRIES_PER_LIST
+      ? arr.slice(0, MAX_AUDIT_ENTRIES_PER_LIST)
+      : (arr || [])
+  );
+
+  try {
+    await UploadAuditModel.create({
+      uploadId: uploadId || crypto.randomUUID(),
+      source,
+      uploadedBy: uploadedBy || 'admin',
+      filename: filename || null,
+      totalRows: uploadResult?.rowCount ?? 0,
+      acceptedRows: uploadResult?.accepted ?? 0,
+      skippedRows: uploadResult?.skipped?.length ?? 0,
+      rejectedRows: uploadResult?.rejected?.length ?? 0,
+      skipped: truncate(uploadResult?.skipped),
+      rejected: truncate(uploadResult?.rejected),
+      bulkWriteResult: uploadResult?.bulkWriteResult
+        || (uploadResult?.insertRes || uploadResult?.deleteRes
+          ? { insertRes: uploadResult.insertRes, deleteRes: uploadResult.deleteRes }
+          : null),
+      status,
+      errorMessage: errorMessage || null,
+    });
+  } catch (err) {
+    // audit logging must never break the actual upload
+    console.error('[upload-audit] failed to persist audit doc:', err);
+  }
+};
+
+/**
+ * @description derives status from upload result counts
+ */
+export const deriveUploadStatus = (uploadResult) => {
+  const rejected = uploadResult?.rejected?.length ?? 0;
+  const accepted = uploadResult?.accepted ?? 0;
+  if (rejected > 0 && accepted > 0) return 'partial';
+  if (rejected > 0 && accepted === 0) return 'failed';
+  return 'success';
+};

--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -27,13 +27,18 @@ export const deleteFile = async (filename, isAbsolutePath) => {
 /**
  * @description processes CSV file into array of objects
  * @param {String} filename name of CSV file to upload
- * @param {Function} [transformRow] optional function to transform a row of data
- * @returns {Promise<{ docs: Object[], rowCount: Number}>} function that takes in filename of CSV and returns promise
+ * @param {Function} [transformRow] optional function to transform a row of data; receives (row, rowNumber)
+ * @param {Object} [options]
+ * @param {Boolean} [options.collectErrors=false] when true, per-row throws are captured in `rejections` instead of failing the whole parse
+ * @returns {Promise<{ docs: Object[], rowCount: Number, rejections: Array}>}
  */
-export const processCSV = (filename, transformRow = (r) => r) => {
+export const processCSV = (filename, transformRow = (r) => r, options = {}) => {
+  const { collectErrors = false } = options;
   const filepath = path.resolve(__dirname, `../../${filename}`);
   const docs = [];
+  const rejections = [];
   let failed = false;
+  let rowNumber = 0;
 
   return new Promise((resolve, reject) => {
     const stream = parseFile(filepath, { headers: true });
@@ -41,12 +46,18 @@ export const processCSV = (filename, transformRow = (r) => r) => {
     stream
       .on('data', (data) => {
         if (failed) return;
+        rowNumber += 1;
+        const currentRow = rowNumber;
         try {
-          docs.push(transformRow(data));
+          docs.push(transformRow(data, currentRow));
         } catch (err) {
-          failed = true;
-          stream.destroy();
-          reject(err);
+          if (collectErrors) {
+            rejections.push({ rowNumber: currentRow, error: err, raw: data });
+          } else {
+            failed = true;
+            stream.destroy();
+            reject(err);
+          }
         }
       })
       .on('error', (err) => {
@@ -56,7 +67,7 @@ export const processCSV = (filename, transformRow = (r) => r) => {
         }
       })
       .on('end', (rowCount) => {
-        if (!failed) resolve({ docs, rowCount });
+        if (!failed) resolve({ docs, rowCount, rejections });
       });
   });
 };
@@ -67,17 +78,35 @@ export const processCSV = (filename, transformRow = (r) => r) => {
  * @param {Function} [transformRow] optional async function to transform a row of data
  * @returns {Promise<{ docs: Object[], rowCount: Number}>} function that takes in filename of CSV and returns promise
  */
-export const processCSVAsync = (filename, transformRow = (r) => Promise.resolve(r)) => {
+export const processCSVAsync = (filename, transformRow = (r) => Promise.resolve(r), options = {}) => {
+  const { collectErrors = false } = options;
   const filepath = path.resolve(__dirname, `../../${filename}`);
   const promises = [];
+  const rejections = [];
+  let rowNumber = 0;
 
   return new Promise((resolve, reject) => {
     parseFile(filepath, { headers: true })
-      .on('data', (data) => promises.push(transformRow(data).catch(reject)))
+      .on('data', (data) => {
+        rowNumber += 1;
+        const currentRow = rowNumber;
+        if (collectErrors) {
+          promises.push(
+            Promise.resolve()
+              .then(() => transformRow(data, currentRow))
+              .catch((err) => {
+                rejections.push({ rowNumber: currentRow, error: err, raw: data });
+                return undefined;
+              }),
+          );
+        } else {
+          promises.push(transformRow(data, currentRow).catch(reject));
+        }
+      })
       .on('error', (err) => reject(err))
       .on('end', async (rowCount) => {
         const docs = await Promise.all(promises).catch(reject);
-        resolve({ docs, rowCount });
+        resolve({ docs, rowCount, rejections });
       });
   });
 };

--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -73,45 +73,6 @@ export const processCSV = (filename, transformRow = (r) => r, options = {}) => {
 };
 
 /**
- * @description processes CSV file into array of objects, allows async transformation of row
- * @param {String} filename name of CSV file to upload
- * @param {Function} [transformRow] optional async function to transform a row of data
- * @returns {Promise<{ docs: Object[], rowCount: Number}>} function that takes in filename of CSV and returns promise
- */
-export const processCSVAsync = (filename, transformRow = (r) => Promise.resolve(r), options = {}) => {
-  const { collectErrors = false } = options;
-  const filepath = path.resolve(__dirname, `../../${filename}`);
-  const promises = [];
-  const rejections = [];
-  let rowNumber = 0;
-
-  return new Promise((resolve, reject) => {
-    parseFile(filepath, { headers: true })
-      .on('data', (data) => {
-        rowNumber += 1;
-        const currentRow = rowNumber;
-        if (collectErrors) {
-          promises.push(
-            Promise.resolve()
-              .then(() => transformRow(data, currentRow))
-              .catch((err) => {
-                rejections.push({ rowNumber: currentRow, error: err, raw: data });
-                return undefined;
-              }),
-          );
-        } else {
-          promises.push(transformRow(data, currentRow).catch(reject));
-        }
-      })
-      .on('error', (err) => reject(err))
-      .on('end', async (rowCount) => {
-        const docs = await Promise.all(promises).catch(reject);
-        resolve({ docs, rowCount, rejections });
-      });
-  });
-};
-
-/**
  * @description higher-order function that creates a csv downloader function
  * @param {mongoose.Model} ModelName destination Model of download
  * @param {Array<String>} fields model attributes in array (used for fields of the csv file)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -21,6 +21,8 @@ import {
 
 import {
   extractObjectFieldsCreator,
+  tryCastDate,
+  tryCastNumber,
   validateNumberEntry,
 } from './validators';
 
@@ -34,10 +36,17 @@ import {
 
 import {
   deleteInsert,
+  MAX_DAYS_ACTIVE,
+  MIN_DAYS_ACTIVE,
   transformSurvey123GlobalID,
 } from './survey123';
 
 import { callRScript } from './r-launcher';
+
+import {
+  persistUploadAudit,
+  deriveUploadStatus,
+} from './audit';
 
 export {
   calculatedFieldsGeneratorCreator,
@@ -45,6 +54,7 @@ export {
   csvStreamDownloadCreator,
   deleteFile,
   deleteInsert,
+  deriveUploadStatus,
   extractObjectFieldsCreator,
   generateErrorResponse,
   generateResponse,
@@ -52,14 +62,19 @@ export {
   getModelIndexes,
   getModelNumericAttributes,
   indicatorGeneratorCreator,
+  MAX_DAYS_ACTIVE,
+  MIN_DAYS_ACTIVE,
   newError,
   offsetYearPassCreator,
+  persistUploadAudit,
   predictionGeneratorCreator,
   processCSV,
   processCSVAsync,
   callRScript,
   transformSurvey123GlobalID,
   trappingAggregationPipelineCreator,
+  tryCastDate,
+  tryCastNumber,
   upsertOpCreator,
   validateNumberEntry,
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,7 +3,6 @@ import {
   csvStreamDownloadCreator,
   deleteFile,
   processCSV,
-  processCSVAsync,
 } from './csv';
 
 import {
@@ -69,7 +68,6 @@ export {
   persistUploadAudit,
   predictionGeneratorCreator,
   processCSV,
-  processCSVAsync,
   callRScript,
   transformSurvey123GlobalID,
   trappingAggregationPipelineCreator,

--- a/src/utils/survey123.js
+++ b/src/utils/survey123.js
@@ -1,5 +1,11 @@
-import { newError } from './responses';
 import { RESPONSE_TYPES } from '../constants';
+import { newError } from './responses';
+
+// Active-days bounds for a survey (sum across 6 weeks).
+// Lower bound 12: anything below is too short to be a real survey.
+// Upper bound 90 covers full 6-week spring surveys spanning ~Mar-May (typically 60-70 days).
+export const MIN_DAYS_ACTIVE = 12;
+export const MAX_DAYS_ACTIVE = 90;
 
 /**
  * @description transforms a survey123 globalID to all lowercase and removes curly braces
@@ -27,9 +33,7 @@ export const deleteInsert = (sixWeeksData) => {
     acc + (parseInt(curr.daysActive, 10) || 0)
   ), 0);
 
-  // only insert if data is valid and between 12 and 90 days total active
-  // upper bound 90 covers full 6-week spring surveys spanning ~Mar-May (typically 60-70 days)
-  const insertOps = shouldInsert && numDaysActive >= 12 && numDaysActive <= 90
+  const insertOps = shouldInsert && numDaysActive >= MIN_DAYS_ACTIVE && numDaysActive <= MAX_DAYS_ACTIVE
     ? sixWeeksData.map((weekData) => ({
       insertOne: {
         document: weekData,

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,3 +1,5 @@
+import numeral from 'numeral';
+
 import { RESPONSE_TYPES } from '../constants';
 import { newError } from './responses';
 
@@ -31,4 +33,34 @@ export const extractObjectFieldsCreator = (fields) => (obj) => {
  */
 export const validateNumberEntry = (value, fallback = null) => {
   return value === undefined || value === null || value === '' ? fallback : value;
+};
+
+/**
+ * @description mirrors the mongoose Number cast from unsummarized-trapping.js:
+ *  - null/undefined → { ok: true, coerced: null }
+ *  - '' → { ok: true, coerced: 0 }
+ *  - parseable via numeral → { ok: true, coerced: number }
+ *  - otherwise → { ok: false }
+ * Used by upload preview to surface CastError-equivalent failures BEFORE bulkWrite.
+ */
+export const tryCastNumber = (value) => {
+  if (value === undefined || value === null) return { ok: true, coerced: null };
+  if (value === '') return { ok: true, coerced: 0 };
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? { ok: true, coerced: value } : { ok: false };
+  }
+  const parsed = numeral(value).value();
+  if (parsed === null || Number.isNaN(parsed)) return { ok: false };
+  return { ok: true, coerced: parsed };
+};
+
+/**
+ * @description checks Date castability the same way mongoose would.
+ * Returns { ok, coerced } where ok=false means mongoose would throw CastError.
+ */
+export const tryCastDate = (value) => {
+  if (value === undefined || value === null || value === '') return { ok: true, coerced: null };
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return { ok: false };
+  return { ok: true, coerced: d };
 };


### PR DESCRIPTION
# Description

Adds preview (dry-run) endpoints for all three CSV uploads (Survey123,
county spots, ranger-district spots) so rejected/skipped rows are surfaced
before anything is written. Persists a per-upload audit record (counts +
reasons, no PII) and exposes a paginated history endpoint.

- Preview endpoints validate + report accepted / skipped / rejected without writing
- Numeric & date cast checks catch CastError-class failures before bulkWrite
- Survey123 active-days cap unified to a single constant (60→90), used by preview + commit
- UploadAudit model + GET /upload-audit (paginated, filterable, query params sanitized)
- Spot lookups batched into one query (no findOne-per-row)
- Webhook flow unchanged (out of scope)


## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/pine-beetle-automation/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782480999&installation_id=133523038&pr_number=218&repository=dali-lab%2Fpine-beetle-automation&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fpine-beetle-automation%2Fpull%2F218&signature=e78b9cce8731776c919eb2ec3810c3fb94539fd71b683f49a6499cf441b11e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->